### PR TITLE
Bop 662 add points

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,8 @@
     "angular-chart.js": "^0.9.0",
     "ng-lodash": "^0.4.0",
     "ngCytoscape": "^0.0.5",
-    "angular-agility": "^0.8.32"
+    "angular-agility": "^0.8.32",
+    "Leaflet.awesome-markers": "^2.0.2"
   },
   "resolutions": {
     "angular": "~1.3",

--- a/config/assets/default.js
+++ b/config/assets/default.js
@@ -11,7 +11,8 @@ module.exports = {
         'public/lib/select2/select2.css',
         'public/lib/select2/select2-bootstrap.css',
         'public/lib/leaflet/dist/leaflet.css',
-        'public/lib/angular-chart.js/dist/angular-chart.css'
+        'public/lib/angular-chart.js/dist/angular-chart.css',
+        'public/lib/Leaflet.awesome-markers/dist/leaflet.awesome-markers.css'
       ],
       js: [
         'public/lib/jquery/dist/jquery.js',
@@ -40,7 +41,8 @@ module.exports = {
         'public/lib/cytoscape/dist/cytoscape.js',
         'public/lib/ngCytoscape/dst/ngCytoscape.js',
         'public/lib/angular-chart.js/dist/angular-chart.js',
-        'public/lib/ng-lodash/build/ng-lodash.min.js'
+        'public/lib/ng-lodash/build/ng-lodash.min.js',
+        'public/lib/Leaflet.awesome-markers/dist/leaflet.awesome-markers.min.js'
       ],
       tests: ['public/lib/angular-mocks/angular-mocks.js']
     },

--- a/modules/core/client/controllers/leaflet-map.client.controller.js
+++ b/modules/core/client/controllers/leaflet-map.client.controller.js
@@ -11,6 +11,7 @@
     var vm = this;
     var mapSelectMap;
     var mapMarker = null;
+    var addPointsGroup = new L.featureGroup();
     
 
     var settings = {
@@ -48,6 +49,18 @@
       moveMarker(latlng);
     };
 
+    var zoomToLevel = function(level){
+      mapSelectMap.setZoom(level);
+    };
+
+    var zoomOut = function(){
+      mapSelectMap.zoomOut();
+    };
+
+    var zoomIn = function(){
+      mapSelectMap.zoomIn();
+    };
+
     activate();
 
     function activate(){
@@ -56,6 +69,9 @@
         vm.mapControls.resizeMap = resizeMap;
         vm.mapControls.moveMarker = moveMarker;
         vm.mapControls.zoomToLocation = zoomToLocation;
+        vm.mapControls.zoomToLevel = zoomToLevel;
+        vm.mapControls.zoomOut = zoomOut;
+        vm.mapControls.zoomIn = zoomIn;
       }
       
       $timeout(function() {
@@ -95,6 +111,12 @@
           });
         }
 
+        if(vm.addPoints && angular.isArray(vm.addPoints)){
+          if(vm.addPoints.length > 0){
+            loadPoints();
+          }
+        }
+
         
       });
 
@@ -106,6 +128,22 @@
         
         angular.element(document.querySelector('#'+vm.modalId)).unbind('shown.bs.modal');
       });
+      
+    }
+
+    function loadPoints(){
+
+      for (var i = 0; i < vm.addPoints.length; i++) {
+        var marker = new L.marker([vm.addPoints[i].lat,vm.addPoints[i].lng],{icon:L.AwesomeMarkers.icon(vm.addPoints[i].icon)});
+
+        addPointsGroup.addLayer(marker);
+
+
+      }
+      mapSelectMap.addLayer(addPointsGroup);
+      mapSelectMap.fitBounds(addPointsGroup.getBounds());
+      zoomOut();
+      
       
     }
   }

--- a/modules/core/client/controllers/leaflet-map.client.controller.js
+++ b/modules/core/client/controllers/leaflet-map.client.controller.js
@@ -133,6 +133,8 @@
 
     function loadPoints(){
 
+      addPointsGroup.clearLayers();
+      
       for (var i = 0; i < vm.addPoints.length; i++) {
         var marker = new L.marker([vm.addPoints[i].lat,vm.addPoints[i].lng],{icon:L.AwesomeMarkers.icon(vm.addPoints[i].icon)});
 

--- a/modules/core/client/directives/leaflet-map.client.directive.js
+++ b/modules/core/client/directives/leaflet-map.client.directive.js
@@ -14,7 +14,8 @@
           mapControls:'=',
           mapClickEvent:'&',
           markerDragEndEvent:'&',
-          showMarker:'='
+          showMarker:'=',
+          addPoints:'='
           
         },
         

--- a/modules/forms/client/README.md
+++ b/modules/forms/client/README.md
@@ -22,16 +22,20 @@ latitude="sample.locationOfWaterSample.latitude" longitude="sample.locationOfWat
 ## Leaflet Map Directive
 ### Usage
 * <leaflet-map map-controls="vm.mapControls" map-click-event="vm.mapClick" marker-drag-end-event="vm.markerDragEnd"
-                                 can-move-marker="vm.canMoveMarker" show-marker="vm.showMarker"></leaflet-map>
+                                 can-move-marker="vm.canMoveMarker" show-marker="vm.showMarker" add-points="[{lat:40.668514 , lng:-74.077721,icon: {icon: 'glyphicon-map-marker',  prefix: 'glyphicon',markerColor: 'green'}},
+                                                                                                {lat:40.600774 , lng:-74.056435,icon: {icon: 'glyphicon-map-marker',  prefix: 'glyphicon',markerColor: 'red'}},
+                                                                                                {lat:40.545488 , lng:-73.949318,icon: {icon: 'glyphicon-map-marker',  prefix: 'glyphicon',markerColor: 'green'}}]"></leaflet-map>
 * *map-controls(=)* - empty object that the directive attaches internal functions to so the calling controller can call functions
 * *map-click-event(&)* - function to call if when the map is clicked
 * *marker-drag-end-event(&)* - function to call when marker drag is done
 * *show-marker(=)* - if true the map marker is visible
 * *can-move-marker(=)* - if true the map marker is draggable if it is visible
+* *add-points(=)* - an array of point objects with associated icon to be loaded on the map, overridding any existing points
 
 
 ### Items To Note
 * the directive uses standard leaflet and not the leaflet directive
+*the directive uses HBOSTIC personal mapbox basemap and needs to be updated for production use
 * the directive uses its link function to set the id of the leaflet map since the ids need to be unique whenever the directive is used, this can be generated in a Service too
 * hbostic added leaflet.client.service to make the global window.L object available to angular and pass linting, not sure what the BOP team does for globals  
 

--- a/modules/restoration-stations/client/views/dashboard.client.view.html
+++ b/modules/restoration-stations/client/views/dashboard.client.view.html
@@ -11,7 +11,9 @@
                     </div>
                     <div class="panel-body">
                       <leaflet-map map-controls="" map-click-event="" marker-drag-end-event=""
-                                   can-move-marker="" show-marker=""></leaflet-map>
+                                   can-move-marker="" show-marker="" add-points="[{lat:40.668514 , lng:-74.077721,icon: {icon: 'glyphicon-map-marker',  prefix: 'glyphicon',markerColor: 'green'}},
+{lat:40.600774 , lng:-74.056435,icon: {icon: 'glyphicon-map-marker',  prefix: 'glyphicon',markerColor: 'red'}},
+{lat:40.545488 , lng:-73.949318,icon: {icon: 'glyphicon-map-marker',  prefix: 'glyphicon',markerColor: 'green'}}]"></leaflet-map>
                       <div class="row">
                             <div class="col-sm-6">
                                 <h5><img ng-src="modules/users/client/img/profile/default.png" class="header-profile-image pull-left" src="modules/users/client/img/profile/default.png"> Team Name<br /><small class="text-muted">Teacher, City, State</small></h5>


### PR DESCRIPTION
PR for adding points to a map, the points are in an array format with an associated bootstrap glyph icon.  Once more requirements are given, fail safe code can be added more integration

on the restoration page, hardcoded points are in the format
add-points="[{lat:40.668514 , lng:-74.077721,icon: {icon: 'glyphicon-map-marker',  prefix: 'glyphicon',markerColor: 'green'}},
{lat:40.600774 , lng:-74.056435,icon: {icon: 'glyphicon-map-marker',  prefix: 'glyphicon',markerColor: 'red'}},
{lat:40.545488 , lng:-73.949318,icon: {icon: 'glyphicon-map-marker',  prefix: 'glyphicon',markerColor: 'green'}}]"
