### PR TITLE
Develop

### DIFF
--- a/modules/core/client/controllers/leaflet-map.client.controller.js
+++ b/modules/core/client/controllers/leaflet-map.client.controller.js
@@ -40,13 +40,6 @@
       }
     };
 
-    var moveMarkerToLocation = function(location) {
-      if(mapMarker){
-        var latLng = L.latLng(location.lat, location.lng);
-        moveMarker(latLng);
-      }
-    };
-
     var zoomToLocation = function(location){
       var latlng = L.latLng(location.lat, location.lng);
       mapSelectMap.setView(latlng, settings.searchZoom, { animate: false });
@@ -79,7 +72,6 @@
       if(vm.mapControls){
         vm.mapControls.resizeMap = resizeMap;
         vm.mapControls.moveMarker = moveMarker;
-        vm.mapControls.moveMarkerToLocation = moveMarkerToLocation;
         vm.mapControls.zoomToLocation = zoomToLocation;
         vm.mapControls.zoomToLevel = zoomToLevel;
         vm.mapControls.zoomOut = zoomOut;

--- a/modules/core/client/controllers/leaflet-map.client.controller.js
+++ b/modules/core/client/controllers/leaflet-map.client.controller.js
@@ -40,6 +40,13 @@
       }
     };
 
+    var moveMarkerToLocation = function(location) {
+      if(mapMarker){
+        var latLng = L.latLng(location.lat, location.lng);
+        moveMarker(latLng);
+      }
+    };
+
     var zoomToLocation = function(location){
       var latlng = L.latLng(location.lat, location.lng);
       mapSelectMap.setView(latlng, settings.searchZoom, { animate: false });
@@ -72,6 +79,7 @@
       if(vm.mapControls){
         vm.mapControls.resizeMap = resizeMap;
         vm.mapControls.moveMarker = moveMarker;
+        vm.mapControls.moveMarkerToLocation = moveMarkerToLocation;
         vm.mapControls.zoomToLocation = zoomToLocation;
         vm.mapControls.zoomToLevel = zoomToLevel;
         vm.mapControls.zoomOut = zoomOut;

--- a/modules/forms/client/controllers/map-select.client.controller.js
+++ b/modules/forms/client/controllers/map-select.client.controller.js
@@ -19,14 +19,6 @@
         angular.element(document.querySelector('#'+vm.modalId)).on('shown.bs.modal', function(){
           $timeout(function() {
             vm.mapControls.resizeMap();
-            if(vm.latitude !== null && vm.longitude !== null) {
-              var initialLocation = {
-                lat: vm.latitude,
-                lng: vm.longitude
-              };
-              vm.mapControls.panTo(initialLocation);
-              vm.mapControls.moveMarkerToLocation(initialLocation);
-            }
           });
         });
       }

--- a/modules/forms/client/controllers/map-select.client.controller.js
+++ b/modules/forms/client/controllers/map-select.client.controller.js
@@ -19,6 +19,14 @@
         angular.element(document.querySelector('#'+vm.modalId)).on('shown.bs.modal', function(){
           $timeout(function() {
             vm.mapControls.resizeMap();
+            if(vm.latitude !== undefined && vm.latitude !== null &&
+               vm.longitude !== undefined && vm.longitude !== null) {
+              var location = {
+                lat: vm.latitude,
+                lng: vm.longitude
+              };
+              vm.mapControls.zoomToLocation(location);
+            }
           });
         });
       }

--- a/modules/forms/client/controllers/map-select.client.controller.js
+++ b/modules/forms/client/controllers/map-select.client.controller.js
@@ -19,6 +19,14 @@
         angular.element(document.querySelector('#'+vm.modalId)).on('shown.bs.modal', function(){
           $timeout(function() {
             vm.mapControls.resizeMap();
+            if(vm.latitude !== null && vm.longitude !== null) {
+              var initialLocation = {
+                lat: vm.latitude,
+                lng: vm.longitude
+              };
+              vm.mapControls.panTo(initialLocation);
+              vm.mapControls.moveMarkerToLocation(initialLocation);
+            }
           });
         });
       }


### PR DESCRIPTION
If a latitude and longitude are set when the map-select component initializes, set the map to point to  be centered on that location and put the marker there. Still bring up the default location if there is no lat/long set. The previous behavior was to bring up the map to a default location even if there was one set.