### PR TITLE
Edit auto-generated team lead pending email copy

### DIFF
--- a/modules/core/server/templates/email-html/lead_pending.html
+++ b/modules/core/server/templates/email-html/lead_pending.html
@@ -25,7 +25,17 @@
 
         <p style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.6em; font-weight: normal; margin: 0 0 10px; padding: 0;">Hi <%= FirstName %>,</p>
 
-        <p style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.6em; font-weight: normal; margin: 0 0 10px; padding: 0;">Thanks for joining the Billion Oyster Project as a Team Lead! Currently, your account is pending admin approval. Until then, you can still log in but won't be able to add content. We'll let you know as soon as your account is fully active!</p>
+        <p style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.6em; font-weight: normal; margin: 0 0 10px; padding: 0;">
+            Thanks for joining the Billion Oyster Project as a Team Lead! You can now:
+            <ul> 
+                <li>View <a href="http://platform.bop.nyc/restoration/stations">Oyster Research Station locations</a></li>
+                <li>View and download <a href="https://platform.bop.nyc/expeditions/data">data</a></li>
+                <li>View <a href="http://platform.bop.nyc/lessons">lessons</a> and <a href="http://platform.bop.nyc/units">units</a></li>
+                <li>View <a href="http://platform.bop.nyc/research">research</a> created by students, teachers, and community scientists</li>
+                <li>View participating <a href="https://platform.bop.nyc/profiles/organization">organizations</a></li>
+                <li>Sign up for <a href="https://platform.bop.nyc/events">events</a></li>
+            </ul>
+            <p>Currently, your account is pending admin approval.  You'll get full access to the platform once you've attended an <a href="https://billionoysterproject.org/training/">Oyster Research Station Basic Training</a>.  We'll send you a confirmation as soon as your account is fully active.  In the interim, check out the <a href="https://github.com/BillionOysterProject/docs/wiki/Digital-Platform-User-Guide-Table-of-Contents">BOP Digital Platform User Guide</a>, and feel free to reply to this email with any questions&ndash; our staff will be in touch right away!</p>
         <br/>
 
         <!-- button -->
@@ -64,7 +74,7 @@
     <tr style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6em; margin: 0; padding: 0;">
     <td align="center" style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6em; margin: 0; padding: 0;">
 
-        <p style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 12px; line-height: 1.6em; color: #666666; font-weight: normal; margin: 0 0 10px; padding: 0;">You are receiving this email because of your Billion Oyster Project account. <a href="<%= LinkProfile %>" style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6em; color: #999999; margin: 0; padding: 0;"><unsubscribe style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6em; margin: 0; padding: 0;">Change email account</unsubscribe></a>. Need help? Just respond to this email and we'll get back to you.</p>
+        <p style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 12px; line-height: 1.6em; color: #666666; font-weight: normal; margin: 0 0 10px; padding: 0;">You are receiving this email because of your Billion Oyster Project account. <a href="<%= LinkProfile %>" style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6em; color: #999999; margin: 0; padding: 0;"><unsubscribe style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 100%; line-height: 1.6em; margin: 0; padding: 0;">Change email account</unsubscribe></a>. </p>
 
     </td>
     </tr>

--- a/modules/core/server/templates/email-text/lead_pending.txt
+++ b/modules/core/server/templates/email-text/lead_pending.txt
@@ -1,9 +1,23 @@
 Hi <%= FirstName %>,
 
-Thanks for joining the Billion Oyster Project as a Team Lead! Currently, your account is pending admin approval. Until then, you can still log in at <%= LinkLogin %> but won't be able to add content. We'll let you know as soon as your account is fully active!
+Thanks for joining the Billion Oyster Project as a Team Lead! You can now log in at <%= LinkLogin %> and...
+
+*View Oyster Research Station locations: http://platform.bop.nyc/restoration/stations
+*View and download data: https://platform.bop.nyc/expeditions/data
+*View lessons: http://platform.bop.nyc/lessons
+*View units: http://platform.bop.nyc/units
+*View research created by students, teachers, and community scientists: http://platform.bop.nyc/research
+*View participating organizations: https://platform.bop.nyc/profiles/organization
+*Sign up for events: https://platform.bop.nyc/events
+           
+Currently, your account is pending admin approval.  You'll get full access to the platform once you've attended an Oyster Research Station Basic Training.  Learn more here: https://billionoysterproject.org/training/
+
+We'll send you a confirmation as soon as your account is fully active.  In the interim, check out the BOP Digital Platform User Guide: https://github.com/BillionOysterProject/docs/wiki/Digital-Platform-User-Guide-Table-of-Contents
+
+And please feel free to reply to this email with any questions- our staff will be in touch right away!
 
 We're glad to have you!
 The Billion Oyster Project
 
 You are receiving this email because of your Billion Oyster Project account. Visit <%= LinkProfile %> to change your email account.
-Need help? Just respond to this email and we'll get back to you.
+


### PR DESCRIPTION
I edited the team lead pending auto-generated email copy (both the html and text templates) to clarify what platform functionality pending users can access and to include links to the ORS Basic Training Page on the main BOP site, as well as the user guide in Github.