### PR TITLE
Remove "Delete" button from "Register your ORS" form

### DIFF
--- a/modules/restoration-stations/client/views/form-restoration-station-content.client.view.html
+++ b/modules/restoration-stations/client/views/form-restoration-station-content.client.view.html
@@ -109,7 +109,6 @@
         </div>
     </div>
     <div class="modal-footer">
-        <button type="button" class="btn btn-danger" ng-show="station._id" ng-click="remove()">Delete</button>
         <button type="button" class="btn btn-default" ng-click="closeFunction()" ng-disabled="disableCancel">Cancel</button>
         <button type="submit" class="btn btn-primary">{{station._id ? 'Update' : 'Register'}}</button>
     </div>


### PR DESCRIPTION
Because of the database structure, deleting an ORS can cause the download data function to stop working.  I'm removing the delete button to prevent this bug from occurring again.