### PR TITLE
Adding auto-generated API and ODM documentation

### DIFF
--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -18,7 +18,9 @@ var config = require('../config'),
   flash = require('connect-flash'),
   consolidate = require('consolidate'),
   path = require('path'),
-  lusca = require('lusca');
+  lusca = require('lusca'),
+  mongoose = require('mongoose'),
+  docs = require('express-mongoose-docs');
 
 /**
  * Initialize local variables
@@ -96,6 +98,7 @@ module.exports.initMiddleware = function (app) {
   // Add the cookie parser and flash middleware
   app.use(cookieParser());
   app.use(flash());
+  docs(app, mongoose);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "docxtemplater": "^2.1.0",
     "docxtemplater-link-module": "0.0.4",
     "express": "~4.13.4",
+    "express-mongoose-docs": "^0.3.2",
     "express-session": "~1.13.0",
     "fast-csv": "^2.1.0",
     "file-stream-rotator": "~0.0.6",
@@ -76,8 +77,8 @@
     "socket.io": "~1.3.7",
     "swig": "~1.4.2",
     "validator": "~4.8.0",
-    "wkhtmltopdf": "~0.3.4",
     "wkhtmltoimage": "^0.1.5",
+    "wkhtmltopdf": "~0.3.4",
     "xml2json": "^0.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This change adds an automatic documentation generator endpoint ([`express-mongoose-docs`](https://www.npmjs.com/package/express-mongoose-docs)) that will provide details on the public-facing RESTful API (via ExpressJS) and backend object data mapper (via Mongoose).

API documentation will be accessible at: https://[dev|staging.]platform.bop.nyc/apiDocs