### PR TITLE
Removing protocol 2 and 4 requirements

### DIFF
--- a/modules/protocol-oyster-measurements/client/views/form-protocol-oyster-measurement.client.view.html
+++ b/modules/protocol-oyster-measurements/client/views/form-protocol-oyster-measurement.client.view.html
@@ -53,30 +53,25 @@
                     <p class="lead blue">Your group is responsible for measuring growth and recording mortality of oysters in the main oyster cage.</p>
                     <h6>Depth of oyster cage</h6>
                     <div class="form-group">
-                        <label for="submergedDepth" class="control-label required">Submerged depth of cage (meters) *</label>
-                        <input type="number" class="form-control" min="0" name="submergedDepth" id="submergedDepth" ng-model="oysterMeasurement.depthOfOysterCage.submergedDepthofCageM" on-blur="saveOnBlur()" required/>
+                        <label for="submergedDepth" class="control-label">Submerged depth of cage (meters)</label>
+                        <input type="number" class="form-control" min="0" name="submergedDepth" id="submergedDepth" ng-model="oysterMeasurement.depthOfOysterCage.submergedDepthofCageM" on-blur="saveOnBlur()"/>
                         <span class="help-block">Method: Record length of wet line from surface to cage.</span>
                     </div>
                 </div>
                 <div class="col-md-6">
                     <h6>Condition of oyster cage</h6>
                     <div class="form-group">
-                        <label>Take a photograph of the oyster cage *</label>
+                        <label>Take a photograph of the oyster cage.</label>
                         <single-image-drop-zone uploader="cageConditionUploader" image-url="cageConditionPhotoURL"
                         image-alt="Oyster Cage Condition" id="oyster-cage-condition-image-dropzone"></single-image-drop-zone>
-                        <div ng-show="form.oysterMeasurementForm.$invalid && form.oysterMeasurementForm.$submitted && !cageConditionPhotoURL">
-                            <p class="red">Oyster cage condition image is required.</p>
-                        </div>
                     </div>
                     <div class="form-group">
-                        <label for="bioaccumulation" class="control-label required">Bioaccumulation on cage *</label>
-                        <select class="form-control" ng-options="bioaccumulation.value as bioaccumulation.label for bioaccumulation in bioaccumulations" ng-model="oysterMeasurement.conditionOfOysterCage.bioaccumulationOnCage"  name="bioaccumulation" id="bioaccumulation" required></select>
+                        <label for="bioaccumulation" class="control-label">Bioaccumulation on cage</label>
+                        <select class="form-control" ng-options="bioaccumulation.value as bioaccumulation.label for bioaccumulation in bioaccumulations" ng-model="oysterMeasurement.conditionOfOysterCage.bioaccumulationOnCage"  name="bioaccumulation" id="bioaccumulation"></select>
                     </div>
                     <div class="form-group">
                         <label for="damage" class="control-label">Describe any damage to the cage</label>
                         <textarea class="form-control" ng-model="oysterMeasurement.conditionOfOysterCage.notesOnDamageToCage" name="damage" id="damage"></textarea>
-
-                        <!--TODO: Wire up link to open status report modal (currently at the bottom of RS Dashboard until it and ORS profiles are wired up)-->
                         <span class="help-block">Was the cage lost, destroyed or significantly damaged? <a class="btn btn-sm btn-danger pull-right" ng-click="openORSStatusForm()">Submit status update</a></span>
                     </div>
 

--- a/modules/protocol-oyster-measurements/server/controllers/protocol-oyster-measurements.server.controller.js
+++ b/modules/protocol-oyster-measurements/server/controllers/protocol-oyster-measurements.server.controller.js
@@ -33,26 +33,30 @@ var checkRole = function(role, user) {
 var validate = function(oysterMeasurement, successCallback, errorCallback) {
   var errorMessages = [];
 
-  if(!oysterMeasurement.depthOfOysterCage || oysterMeasurement.depthOfOysterCage.submergedDepthofCageM === undefined ||
-    oysterMeasurement.depthOfOysterCage.submergedDepthofCageM === null) {
-    errorMessages.push('Submerged depth of oyster cage is required and must be greater than 0');
-  } else if(oysterMeasurement.depthOfOysterCage.submergedDepthofCageM < 0) {
-    errorMessages.push('Submerged depth of oyster cage must be greater than 0');
-  }
+  // TODO: clean up this code later- remove depth of cage requirement.
+  // if(!oysterMeasurement.depthOfOysterCage || oysterMeasurement.depthOfOysterCage.submergedDepthofCageM === undefined ||
+  //   oysterMeasurement.depthOfOysterCage.submergedDepthofCageM === null) {
+  //   errorMessages.push('Submerged depth of oyster cage is required and must be greater than 0');
+  // } else if(oysterMeasurement.depthOfOysterCage.submergedDepthofCageM < 0) {
+  //   errorMessages.push('Submerged depth of oyster cage must be greater than 0');
+  // }
+ 
+  // TODO: clean up this code later- removing requirements to upload a photo of the cage
+  // and removing requirement to describe bioaccumulation.
+  // if (!oysterMeasurement.conditionOfOysterCage) {
+  //   errorMessages.push('Cage Condition photo is required');
+  //   errorMessages.push('Bioaccumulation on cage is required');
+  // } else {
 
-  if (!oysterMeasurement.conditionOfOysterCage) {
-    errorMessages.push('Cage Condition photo is required');
-    errorMessages.push('Bioaccumulation on cage is required');
-  } else {
-    if (!oysterMeasurement.conditionOfOysterCage.oysterCagePhoto ||
-      oysterMeasurement.conditionOfOysterCage.oysterCagePhoto.path === undefined ||
-      oysterMeasurement.conditionOfOysterCage.oysterCagePhoto.path === '') {
-      errorMessages.push('Photo of oyster cage is required');
-    }
-    if (emptyString(oysterMeasurement.conditionOfOysterCage.bioaccumulationOnCage)) {
-      errorMessages.push('Bioaccumulation on cage is required');
-    }
-  }
+  //   if (!oysterMeasurement.conditionOfOysterCage.oysterCagePhoto ||
+  //     oysterMeasurement.conditionOfOysterCage.oysterCagePhoto.path === undefined ||
+  //     oysterMeasurement.conditionOfOysterCage.oysterCagePhoto.path === '') {
+  //     errorMessages.push('Photo of oyster cage is required');
+  //   }
+  //   if (emptyString(oysterMeasurement.conditionOfOysterCage.bioaccumulationOnCage)) {
+  //     errorMessages.push('Bioaccumulation on cage is required');
+  //   }
+  // }
 
   if (!oysterMeasurement.measuringOysterGrowth || !oysterMeasurement.measuringOysterGrowth.substrateShells ||
     oysterMeasurement.measuringOysterGrowth.substrateShells.length < 0) {

--- a/modules/protocol-settlement-tiles/client/views/form-protocol-settlement-tile.client.view.html
+++ b/modules/protocol-settlement-tiles/client/views/form-protocol-settlement-tile.client.view.html
@@ -73,7 +73,7 @@
                         <textarea rows="5" class="form-control" ng-model="tile.description" ></textarea>
                     </div>
                     <div class="form-group">
-                        <label>Tile photograph *</label>
+                        <label>Tile photograph <span ng-if="$index==0">*</span></label>
                         <single-image-drop-zone uploader="settlementTilePhotoUploaders[$index]"
                         image-url="tile.imageUrl" image-alt="Settlement Tile #{{$index+1}} Photo"
                         remove-function="removeImage" id="settlement-tile-image-dropzone-{{$index}}"></single-image-drop-zone>


### PR DESCRIPTION
Per conversations from September 2017 with Schools + Reefs, this commit changes the following fields for Protocol 2 from required to optional (for both the validation on the backend and the language/display on the front end):

- Submerged depth of cage
- Photograph of the oyster cage
- Bioaccumulation on the page

For Protocol 4, only one photo of a settlement tile is required by the system, but each settlement tile had an asterisk in the UI, making it seem like four photos were required.  This removes the asterisk from three of the tiles.