### PR TITLE
fix(Lessons): set links to open in new tab

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,7 @@
 ---
 
 ---
-Billion Oyster Project Updates
+Billion Oyster Project Schools and Community Science Resources
+
+
+

--- a/modules/lessons/client/views/view-lesson-content.client.view.html
+++ b/modules/lessons/client/views/view-lesson-content.client.view.html
@@ -35,7 +35,7 @@
     <div class="col-sm-12">
       <img ng-if="fullPage" class="pull-right" alt="Billion Oyster Project" src="modules/core/client/img/brand/logo.svg" style="width: 100px; height: 128px" />
       <h2 ng-if="fullPage" class="blue"><b>{{lesson.title}}</b></h2>
-      
+
       <h5 id="lesson-author-info" ng-if="lesson.user">
         <img ng-src="{{lesson.user.profileImageURL}}" alt="{{lesson.user.displayName}}" class="img-circle pull-left col-sm-1 col-xs-3" ng-if="!fullPage">
         <b><a ng-click="openViewUserModal()">{{lesson.user.displayName}}</a></b><br>
@@ -121,7 +121,7 @@
       </div>
   </div>
 
-  <div class="row">
+  <div class="row lesson-body">
     <div class="col-sm-3" ng-if="showSidebar">
       <div ng-if="lesson.materialsResources.supplies">
           <b>Supplies</b><br/>
@@ -434,3 +434,20 @@
     </div>
   </div>
 </div>
+
+<!--
+HACK: Convert ALL links in the lesson body to target=_blank
+      regardless of what was set using the Summernote (WYSIWYG) editor.
+-->
+<script type="text/javascript">
+  $(function(){
+    $('.lesson-body a').each(function(i, el){
+        var link = $(el);
+
+        if (link.attr('target') != '_blank') {
+            link.attr('target', '_blank');
+            console.debug('Added target=_blank to link', link.attr('href'));
+        }
+    });
+  });
+</script>


### PR DESCRIPTION
Per Ann's request, in lessons, open all links in a new tab (regardless of what was selected in the Summernote WYSIWYG editor).

UN: bop-admin