### PR TITLE
Add UserID to Google Analytics tracking

### DIFF
--- a/modules/core/client/controllers/header.client.controller.js
+++ b/modules/core/client/controllers/header.client.controller.js
@@ -6,6 +6,12 @@ angular.module('core').controller('HeaderController', ['$scope', '$state', 'Auth
     $scope.$state = $state;
     $scope.authentication = Authentication;
 
+    // Google Analytics: if we're logged in and have a user object, send the
+    // user's ID to Google so we can track them across devices.
+    if (ga && $scope.authentication.user) {
+      ga('set', 'userId', $scope.authentication.user.username);
+    }
+
     // Get the topbar menu
     $scope.menu = Menus.getMenu('topbar');
 


### PR DESCRIPTION
The current Google Analytics set up tracks user activity based on a (numerical, not personally identifiable) Google-generated Client ID that is currently incapable of tracking a user across multiple devices or browsers.  This gives us an artificially inflated number of users, sessions, and pageviews.  By adding code that links a BOP user ID (also a numerical, not personally identifiable string) to the Client ID, when a user logs into the platform, their visits won't be double counted when they use different devices/browsers, and we'll have a more accurate picture of user activity. 

UN: bop-admin

