### PR TITLE
<feat>New Sign-up Page

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -43,7 +43,8 @@
     "angular-summernote": "~0.4.2",
     "raty-fa": "ratyfa#^0.1.2",
     "imagesloaded": "^4.1.1",
-    "angular-socialshare": "angularjs-socialshare#^2.3.8"
+    "angular-socialshare": "angularjs-socialshare#^2.3.8",
+    "angular-ui-select": "^0.19.8"
   },
   "resolutions": {
     "angular": "~1.3",

--- a/config/assets/default.js
+++ b/config/assets/default.js
@@ -16,7 +16,8 @@ module.exports = {
         'public/lib/angular-bootstrap-colorpicker/css/colorpicker.min.css',
         'public/lib/bootstrap-iconpicker/bootstrap-iconpicker/css/bootstrap-iconpicker.min.css',
         'public/lib/Leaflet.awesome-markers/dist/leaflet.awesome-markers.css',
-        'public/lib/angular-bootstrap-calendar/dist/css/angular-bootstrap-calendar.css'
+        'public/lib/angular-bootstrap-calendar/dist/css/angular-bootstrap-calendar.css',
+        'public/lib/angular-ui-select/dist/select.css'
       ],
       js: [
         'public/lib/jquery/dist/jquery.js',
@@ -58,7 +59,8 @@ module.exports = {
         'public/lib/Leaflet.awesome-markers/dist/leaflet.awesome-markers.min.js',
         'public/lib/angular-isotope/dist/angular-isotope.js',
         'public/lib/angular-bootstrap-calendar/dist/js/angular-bootstrap-calendar-tpls.js',
-        'public/lib/angular-socialshare/dist/angular-socialshare.js'
+        'public/lib/angular-socialshare/dist/angular-socialshare.js',
+        'public/lib/angular-ui-select/dist/select.js'
       ],
       tests: ['public/lib/angular-mocks/angular-mocks.js']
     },

--- a/modules/core/client/app/config.js
+++ b/modules/core/client/app/config.js
@@ -25,7 +25,8 @@ var ApplicationConfiguration = (function () {
     'colorpicker.module',
     'angularMoment',
     'mwl.calendar',
-    '720kb.socialshare'];
+    '720kb.socialshare',
+    'ui.select'];
 
   // Add a new vertical module
   var registerModule = function (moduleName, dependencies) {

--- a/modules/core/server/controllers/email.server.controller.js
+++ b/modules/core/server/controllers/email.server.controller.js
@@ -132,7 +132,7 @@ exports.sendBugReport = function(req, res) {
     Issue: req.body.issue
   };
   var email = (req.user) ? req.user.email : defaultFrom;
-  exports.sendFeedback('jira@fearless.jira.com', email, req.body.subject, data, 'bug_report', req, res);
+  exports.sendFeedback('bop.digital.platform@nyharbor.org', email, req.body.subject, data, 'bug_report', req, res);
 };
 
 exports.sendGeneralFeedback = function(req, res) {

--- a/modules/core/server/helpers/pivot.server.helper.js
+++ b/modules/core/server/helpers/pivot.server.helper.js
@@ -1,90 +1,90 @@
 'use strict';
 
-const url               = require('url');
-const request           = require('request');
-const querystring       = require('querystring');
-const DEFAULT_PIVOT_URI = 'http://localhost:29029';
+var url = require('url'),
+  request = require('request'),
+  querystring = require('querystring'),
+  DEFAULT_PIVOT_URI = 'http://localhost:29029';
 
 function Pivot() {
-    this.url = DEFAULT_PIVOT_URI;
-};
+  this.url = DEFAULT_PIVOT_URI;
+}
 
 function Collection(name, client) {
-    this.name   = name;
-    this.client = client;
-};
+  this.name = name;
+  this.client = client;
+}
 
 Pivot.prototype.setUrl = function(url) {
-    this.url = url;
+  this.url = url;
 };
 
 Pivot.prototype.collection = function(name) {
-    return new Collection(name, this);
+  return new Collection(name, this);
 };
 
 Pivot.prototype.request = function(path, callback, options) {
-    var requestUrl = url.resolve(this.url, path);
+  var requestUrl = url.resolve(this.url, path);
 
-    if (options) {
-        if (options.sort instanceof Array) {
-            options.sort = options.sort.join(',');
-        }
-
-        if (options.limit === false) {
-            options.limit = 2147483647;
-        }
-
-        requestUrl += '?' + querystring.stringify(options);
+  if (options) {
+    if (options.sort instanceof Array) {
+      options.sort = options.sort.join(',');
     }
 
-    return request(requestUrl, {
-        json: true,
-    }, function(err, res, body) {
-        if (res.statusCode >= 400) {
-            err = 'HTTP ' + res.statusCode;
+    if (options.limit === false) {
+      options.limit = 2147483647;
+    }
 
-            if (body.error) {
-                err += ': ' + body.error;
-            }
-        };
+    requestUrl += '?' + querystring.stringify(options);
+  }
 
-        callback(err, res, body);
-    });
-}
+  return request(requestUrl, {
+    json: true,
+  }, function(err, res, body) {
+    if (res.statusCode >= 400) {
+      err = 'HTTP ' + res.statusCode;
+
+      if (body.error) {
+        err += ': ' + body.error;
+      }
+    }
+
+    callback(err, res, body);
+  });
+};
 
 Collection.prototype.all = function(callback, options) {
-    this.query('all', callback, options);
+  this.query('all', callback, options);
 };
 
 
 Collection.prototype.query = function(filter, callback, options) {
-    this.client.request(
-        '/api/collections/' +  this.name + '/where/' + filter,
-        function(err, res, body) {
-            var records = [];
+  this.client.request(
+    '/api/collections/' + this.name + '/where/' + filter,
+    function(err, res, body) {
+      var records = [];
 
-            body.records.forEach(function(record, i) {
-                var r = (record.fields || {});
-                r.id = record.id;
-                records.push(r);
-            })
+      body.records.forEach(function(record, i) {
+        var r = (record.fields || {});
+        r.id = record.id;
+        records.push(r);
+      });
 
-            callback(err, records);
-        },
-        options
-    );
+      callback(err, records);
+    },
+    options
+  );
 };
 
 Collection.prototype.get = function(id, callback, options) {
-    this.client.request(
-        '/api/collections/' + this.name + '/records/' + id,
-        function(err, res, body) {
-            var record = (body.fields || {});
-            record.id = body.id;
-            callback(err, record);
-        },
-        options
-    );
+  this.client.request(
+    '/api/collections/' + this.name + '/records/' + id,
+    function(err, res, body) {
+      var record = (body.fields || {});
+      record.id = body.id;
+      callback(err, record);
+    },
+    options
+  );
 };
 
 

--- a/modules/core/server/helpers/pivot.server.helper.js
+++ b/modules/core/server/helpers/pivot.server.helper.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const url               = require('url');
+const request           = require('request');
+const querystring       = require('querystring');
+const DEFAULT_PIVOT_URI = 'http://localhost:29029';
+
+function Pivot() {
+    this.url = DEFAULT_PIVOT_URI;
+};
+
+function Collection(name, client) {
+    this.name   = name;
+    this.client = client;
+};
+
+Pivot.prototype.setUrl = function(url) {
+    this.url = url;
+};
+
+Pivot.prototype.collection = function(name) {
+    return new Collection(name, this);
+};
+
+Pivot.prototype.request = function(path, callback, options) {
+    var requestUrl = url.resolve(this.url, path);
+
+    if (options) {
+        if (options.sort instanceof Array) {
+            options.sort = options.sort.join(',');
+        }
+
+        if (options.limit === false) {
+            options.limit = 2147483647;
+        }
+
+        requestUrl += '?' + querystring.stringify(options);
+    }
+
+    return request(requestUrl, {
+        json: true,
+    }, function(err, res, body) {
+        if (res.statusCode >= 400) {
+            err = 'HTTP ' + res.statusCode;
+
+            if (body.error) {
+                err += ': ' + body.error;
+            }
+        };
+
+        callback(err, res, body);
+    });
+}
+
+Collection.prototype.all = function(callback, options) {
+    this.query('all', callback, options);
+};
+
+
+Collection.prototype.query = function(filter, callback, options) {
+    this.client.request(
+        '/api/collections/' +  this.name + '/where/' + filter,
+        function(err, res, body) {
+            var records = [];
+
+            body.records.forEach(function(record, i) {
+                var r = (record.fields || {});
+                r.id = record.id;
+                records.push(r);
+            })
+
+            callback(err, records);
+        },
+        options
+    );
+};
+
+Collection.prototype.get = function(id, callback, options) {
+    this.client.request(
+        '/api/collections/' + this.name + '/records/' + id,
+        function(err, res, body) {
+            var record = (body.fields || {});
+            record.id = body.id;
+            callback(err, record);
+        },
+        options
+    );
+};
+
+
+var pivot = module.exports = exports = new Pivot();

--- a/modules/school-orgs/server/models/school-org.server.model.js
+++ b/modules/school-orgs/server/models/school-org.server.model.js
@@ -26,6 +26,15 @@ var SchoolOrgSchema = new Schema({
     default: 'other',
     required: 'Organization type cannot be blank'
   },
+  schoolType: {
+    type: String,
+    enum: [
+      'nyc-public',
+      'nyc-charter',
+      'private',
+      'other-public',
+    ],
+  },
   description: {
     type: String,
     default: '',

--- a/modules/users/client/controllers/authentication.client.controller.js
+++ b/modules/users/client/controllers/authentication.client.controller.js
@@ -28,11 +28,11 @@ angular.module('users').controller('AuthenticationController', ['$scope', '$root
 
       if (!isValid) {
         $scope.$broadcast('show-errors-check-validity', 'userForm');
-
         return false;
       }
 
       vm.isSubmitting = true;
+
       $http.post('/api/auth/signup', vm.credentials).success(function (response) {
         vm.isSubmitting = false;
         // If successful we assign the response to the global user model

--- a/modules/users/client/controllers/authentication.client.controller.js
+++ b/modules/users/client/controllers/authentication.client.controller.js
@@ -18,6 +18,25 @@ angular.module('users').controller('AuthenticationController', ['$scope', '$root
       $location.path('/');
     }
 
+    vm.schoolOrgs = [];
+    vm.prospectiveOrgs = [];
+
+    $http.get('/api/school-orgs').success(function(response) {
+      vm.schoolOrgs = response;
+    });
+
+    $http.get('https://platform-beta.bop.nyc/api/prospective-orgs/?limit=10000&fields=name&sort=name').success(function(response) {
+      vm.prospectiveOrgs = response;
+    });
+
+    $scope.$watch('credentials.schoolOrg', function() {
+      console.debug(arguments);
+    });
+
+    vm.updateAutocompleteList = function(){
+      console.debug(arguments);
+    };
+
     vm.signup = function (isValid) {
       if(!vm.hasAcceptedTermsOfUse) {
         vm.error = 'Please read and agree to the Terms of Use before completing sign up.';

--- a/modules/users/client/views/authentication/signup.client.view.html
+++ b/modules/users/client/views/authentication/signup.client.view.html
@@ -1,17 +1,17 @@
 <div class="row">
     <div class="col-md-8">
-        <div style="margin: 19px"> 
+        <div style="margin: 19px">
             <h2>Sign up</h2>
             <p>Already have an account? <a ui-sref="authentication.signin" class="show-signup">Sign in</a></p>
-        </div>    
+        </div>
         <div class="well">
             <p>
-                At Billion Oyster Project, we believe that teamwork is fundamental to restoring New York Harbor!  That’s why we’ve designed the BOP Digital Platform to support <strong>teams</strong> managed by adult <strong>team leads</strong> and composed of student <strong>team members</strong>.  Each team belongs to an <strong>organization</strong> like a school, non-profit, or business.  
+                At Billion Oyster Project, we believe that teamwork is fundamental to restoring New York Harbor!  That’s why we’ve designed the BOP Digital Platform to support <strong>teams</strong> managed by adult <strong>team leads</strong> and composed of student <strong>team members</strong>.  Each team belongs to an <strong>organization</strong> like a school, non-profit, or business.
             </p>
             <p>
                 (If you’re a volunteer community scientist- our name for “citizen scientist”- who isn’t representing an organization, not to worry!  Just select “Unaffiliated/None” as your organization.)
             </p>
-        </div>    
+        </div>
         <br/>
         <form
             name="vm.userForm"
@@ -241,16 +241,55 @@
                     </div>
                 </div>
 
-                <!-- ORGANIZATION (NYC Public Schools) -->
+                <!-- ORGANIZATION -->
                 <!-- =============================================================================================== -->
-                <div class="row" ng-show="
-                    vm.credentials.schoolOrgType == 'teacher' && vm.credentials.schoolOrgType=='nyc-public'
-                ">
+                <div class="row" >
                     <div class="form-group col-sm-12" show-errors>
                         <label for="schoolOrg" class="control-label required">Organization</label>
-                        <span class="help-block">
-                            Start typing your school’s name, number, or ATS code in the field below, then select your school from the dropdown list.
+
+                        <!-- NYC Public School Teacher help text -->
+                        <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+                        <span
+                            class="help-block"
+                            ng-show="
+                                vm.credentials.teamLeadType == 'teacher' && vm.credentials.schoolOrgType=='nyc-public'
+                            "
+                        >
+                            Start typing your school's name, number, or ATS code in the field below, then select your school from the dropdown list.
                         </span>
+
+                        <!-- All others help text -->
+                        <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+                        <span
+                            class="help-block"
+                            ng-hide="
+                                vm.credentials.teamLeadType == 'teacher' && vm.credentials.schoolOrgType=='nyc-public'
+                            "
+                        >
+                            <p>
+                                Start typing your organization's name in the field below, then
+                                select your organization from the dropdown list.  If you're a
+                                community scientist who isn't representing an organization, select
+                                "Unaffiliated/None."
+                            </p>
+                            <p ng-hide="vm.credentials.userrole === 'team member pending'">
+                                If your organization is not listed above, you can
+                                <a href="#" ng-click="vm.openFormOrg()">add an organization</a>.
+                            </p>
+                        </span>
+
+                        <ui-select
+                            ng-model="vm.credentials.schoolOrg"
+                        >
+                            <ui-select-match>
+                                <span ng-bind="$select.selected.name"></span>
+                            </ui-select-match>
+                            <ui-select-choices repeat="item in vm.schoolOrgs | orderBy:'name' | filter:$select.search">
+                                <span ng-bind="item.name"></span>
+                            </ui-select-choices>
+                        </ui-select>
+
+                        <!--
                         <select
                             class="form-control"
                             name="schoolOrg"
@@ -264,61 +303,30 @@
                                 {{schoolOrg.name}}
                             </option>
                         </select>
-                        <span class="help-block">
+                        -->
+
+                        <!-- NYC Public School Teacher help text -->
+                        <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+                        <span
+                            class="help-block"
+                            ng-show="
+                                vm.credentials.teamLeadType == 'teacher' && vm.credentials.schoolOrgType=='nyc-public'
+                            "
+                        >
                             Note: If you work at a NYC public school, your school should already appear as an organization in this list.  If you don't see your NYC public school on the list, contact <a href="mailto:bop.digital.platform@nyharbor.org">bop.digital.platform@nyharbor.org</a>.
                         </span>
-                    </div>
-                </div>
 
-                <!-- ORGANIZATION (all other team leads) -->
-                <!-- =============================================================================================== -->
-                <div class="row" ng-hide="vm.credentials.schoolOrgType=='nyc-public'">
-                    <div class="form-group col-sm-12" show-errors>
-                        <label for="schoolOrg" class="control-label required">Organization</label>
-                        <span class="help-block">
-                            Start typing your organization's name in the field below, then select your organization from the dropdown list.  If you're a community scientist who isn't representing an organization, select "Unaffiliated/None."
-                        </span>
-                         <span class="help-block">
-                            If your organization is not listed above, you can <a href="#" ng-click="vm.openFormOrg()">add an organization</a>.
-                        </span>
-                        <select
-                            class="form-control"
-                            name="schoolOrg"
-                            id="schoolOrg"
-                            ng-model="vm.credentials.schoolOrg"
-                            ng-change="vm.schoolOrgFieldSelected(vm.credentials.schoolOrg)"
-                            ng-disabled="!vm.credentials.teamLeadType || (vm.credentials.teamLeadType == 'teacher' && !vm.credentials.schoolOrgType)"
-                            required>
-                            <option ng-repeat="schoolOrg in vm.schoolOrgs" value="{{schoolOrg._id}}">{{schoolOrg.name}}</option>
-                        </select>
-                         <span class="help-block">
+                        <!-- All others help text -->
+                        <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+                        <span
+                            class="help-block"
+                            ng-hide="
+                                (vm.credentials.teamLeadType == 'teacher' && vm.credentials.schoolOrgType=='nyc-public') ||
+                                vm.credentials.userrole === 'team member pending'
+                            "
+                        >
                             Note: only select "Billion Oyster Project" if you are a staff member at Billion Oyster Project.
                         </span>
-                    </div>
-                </div>
-
-                <!-- FOR TEAM MEMBERS -->
-
-                <!--ORGANIZATION (team members).  Hides "Add an org" text.-->
-                <!-- =============================================================================================== -->
-                <div class="row" ng-show="vm.credentials.userrole === 'team member pending'">
-                    <div class="form-group col-sm-12" show-errors>
-                        <label for="schoolOrg" class="control-label required">Organization
-                            <a href="#" ng-click="vm.openFormOrg()"></a>
-                        </label>
-                        <span class="help-block">
-                            Start typing your organization's name in the field below, then select your organization from the dropdown list."
-                        </span>
-                        <select
-                            class="form-control"
-                            name="schoolOrg"
-                            id="schoolOrg"
-                            ng-model="vm.credentials.schoolOrg"
-                            ng-change="vm.schoolOrgFieldSelected(vm.credentials.schoolOrg)"
-                            ng-disabled="!vm.credentials.teamLeadType || (vm.credentials.teamLeadType == 'teacher' && !vm.credentials.schoolOrgType)"
-                            required>
-                            <option ng-repeat="schoolOrg in vm.schoolOrgs" value="{{schoolOrg._id}}">{{schoolOrg.name}}</option>
-                        </select>
                     </div>
                 </div>
 
@@ -451,3 +459,9 @@ cancel-function="vm.cancelSchoolOrgForm"></form-school-org-modal> -->
     </div>
 </div>
 <!--END MODALS-->
+
+<script type="text/javascript">
+    $(function(){
+
+    });
+</script>

--- a/modules/users/client/views/authentication/signup.client.view.html
+++ b/modules/users/client/views/authentication/signup.client.view.html
@@ -6,52 +6,150 @@
       <form name="vm.userForm" ng-submit="vm.signup(vm.userForm.$valid)" class="signin" novalidate autocomplete="off">
         <fieldset>
           <div class="row">
-              <div class="form-group col-sm-6" show-errors>
-                <label for="firstName">First Name</label>
-                <input type="text" id="firstName" name="firstName" class="form-control" ng-model="vm.credentials.firstName"
-                  placeholder="First Name" required>
-                <div ng-messages="vm.userForm.firstName.$error" role="alert">
-                  <p class="help-block error-text" ng-message="required">First name is required.</p>
-                </div>
+            <div class="form-group col-sm-8" show-errors>
+              <label for="firstName">First Name</label>
+              <input type="text" id="firstName" name="firstName" class="form-control" ng-model="vm.credentials.firstName"
+                placeholder="First Name" required>
+              <div ng-messages="vm.userForm.firstName.$error" role="alert">
+                <p class="help-block error-text" ng-message="required">First name is required.</p>
               </div>
-              <div class="form-group col-sm-6" show-errors>
-                <label for="lastName">Last Name</label>
-                <input type="text" id="lastName" name="lastName" class="form-control" ng-model="vm.credentials.lastName"
-                  placeholder="Last Name" required>
-                <div ng-messages="vm.userForm.lastName.$error" role="alert">
-                  <p class="help-block error-text" ng-message="required">Last name is required.</p>
-                </div>
-              </div>
-          </div>
-          <div class="form-group" show-errors>
-            <label for="email">Email</label>
-            <input type="email" id="email" name="email" class="form-control" ng-model="vm.credentials.email"
-            ng-pattern="/^\w+([.-]?\w+)@\w+([.-]?\w+)(.\w{2,3})+$/" placeholder="email@example.com" lowercase required>
-            <div ng-messages="vm.userForm.email.$error" role="alert">
-              <p class="help-block error-text" ng-message="required">Email address is required.</p>
-              <p class="help-block error-text" ng-message="email">Email address is invalid.</p>
             </div>
           </div>
+          <div class="row">    
+            <div class="form-group col-sm-8" show-errors>
+              <label for="lastName">Last Name</label>
+              <input type="text" id="lastName" name="lastName" class="form-control" ng-model="vm.credentials.lastName"
+                placeholder="Last Name" required>
+              <div ng-messages="vm.userForm.lastName.$error" role="alert">
+                <p class="help-block error-text" ng-message="required">Last name is required.</p>
+              </div>
+            </div>
+          </div>
+          <div class="row">
+            <div class="form-group col-sm-8" show-errors>
+              <label for="email">Email</label>
+              <input type="email" id="email" name="email" class="form-control" ng-model="vm.credentials.email"
+              ng-pattern="/^\w+([.-]?\w+)@\w+([.-]?\w+)(.\w{2,3})+$/" placeholder="email@example.com" lowercase required>
+              <div ng-messages="vm.userForm.email.$error" role="alert">
+                <p class="help-block error-text" ng-message="required">Email address is required.</p>
+                <p class="help-block error-text" ng-message="email">Email address is invalid.</p>
+              </div>
+            </div>
+        </div>
+
         <div class="row">
-          <div class="form-group" show-errors
-          ng-class="{'col-sm-6': !vm.schoolOrgSelected && !vm.teamLeadSelected, 'col-sm-4': vm.schoolOrgSelected || vm.teamLeadSelected}">
+          <div class="form-group col-sm-4" show-errors>
             <label for="role" class="control-label required">Role</label>
-            <select name="role" class="form-control" ng-model="vm.credentials.userrole" required
+            <div class="radio">
+              <label>
+                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
+                Adult - Team Lead
+              </label>
+            </div>
+            <div class="radio">
+              <label>
+                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
+                Student - Team Member
+              </label>
+            </div>
+
+
+           <!--  <select name="role" class="form-group" ng-model="vm.credentials.userrole" required
             ng-change="vm.roleFieldSelected(vm.credentials.userrole)">
               <option value="team lead pending">Team Lead</option>
               <option value="team member pending">Team Member</option>
-            </select>
+            </select> -->
           </div>
+
+          <div class="form-group col-sm-8">
+             <span class="help-block">
+              The platform has two roles- “team lead” for adults and “team member” for students.  Team leads assign activities (like data collection protocols) to team members.  Team leads are also responsible for reviewing any data or content submitted by team members.
+            </span>
+          </div>
+
+          <div class="row">
+          <div class="form-group col-sm-4" show-errors>
+            <label for="role" class="control-label required">Team Lead Type</label>
+            <div class="radio">
+              <label>
+                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
+                Teacher
+              </label>
+            </div>
+            <div class="radio">
+              <label>
+                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
+                Non-profit Partner/Informal Educator
+              </label>
+            </div>
+             <div class="radio">
+              <label>
+                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
+                Community Scientist
+              </label>
+            </div>
+             <div class="radio">
+              <label>
+                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
+                Professional Scientist
+              </label>
+            </div>
+             <div class="radio">
+              <label>
+                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
+                Other
+              </label>
+            </div>
+          </div>
+           <div class="form-group col-sm-8">
+             <span class="help-block">
+              Select the type that most closely describes what you do.  “Community scientist” is the term we use for a volunteer citizen scientist.
+             </span>
+            </div> 
+           <div class="row">
+          <div class="form-group col-sm-4" show-errors>
+            <label for="role" class="control-label required">School Type</label>
+            <div class="radio">
+              <label>
+                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
+                NYC Public
+              </label>
+            </div>
+            <div class="radio">
+              <label>
+                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
+                NYC Charter
+              </label>
+            </div>
+             <div class="radio">
+              <label>
+                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
+                Private
+              </label>
+            </div>
+             <div class="radio">
+              <label>
+                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
+                Other public
+              </label>
+            </div>
+            <div class="form-group col-sm-8">
+             <span class="help-block">
+              
+             </span>
+            </div> 
+          </div>  
           <div class="form-group" show-errors ng-show="vm.teamLeadSelected"
-          ng-class="{'col-sm-6': !vm.teamLeadSelected, 'col-sm-4': vm.teamLeadSelected}">
+          ng-class="{'col-sm-8': !vm.teamLeadSelected, 'col-sm-8': vm.teamLeadSelected}">
             <label for="teamLeadType" class="control-label" ng-class="{required: vm.teamLeadSelected}">Team Lead Type</label>
             <select class="form-control" name="teamLeadType" id="teamLeadType" ng-model="vm.credentials.teamLeadType"
               ng-required="vm.teamLeadSelected">
               <option ng-repeat="type in vm.teamLeadType" value="{{type.value}}">{{type.label}}</option>
             </select>
           </div>
-          <div class="form-group" show-errors
-          ng-class="{'col-sm-6': !vm.schoolOrgSelected && !vm.teamLeadSelected, 'col-sm-4': vm.schoolOrgSelected || vm.teamLeadSelected}">
+        </div>
+        <div class="row">
+          <div class="form-group col-sm-12" show-errors>
             <label for="schoolOrg" class="control-label required">Organization
               <a href="#" ng-click="vm.openFormOrg()" ng-show="vm.credentials.userrole === 'team lead pending'">(not listed?)</a>
             </label>
@@ -131,16 +229,6 @@
           </div>
         </fieldset>
       </form>
-    </div>
-
-    <div class="col-md-4">
-      <br/><br/><br/>
-      <div class="well">
-        <h4 class="red">Not sure what your role is?</h4>
-        <p><b>If you're a student</b>, sign up with the role of Team Member. You can then select your Organization and Team Lead to request to join a team.</p>
-        <p><b>If you're over 18</b>, sign up with the role of Team Lead. This will allow you to create teams, register for an event, view curriculum, upload data, and more.</p>
-        <p>Questions? Click the <i class="fa fa-question-circle"></i> button on the top right of your screen.</p>
-      </div>
     </div>
 </div>
 

--- a/modules/users/client/views/authentication/signup.client.view.html
+++ b/modules/users/client/views/authentication/signup.client.view.html
@@ -1,245 +1,360 @@
 <div class="row">
     <div class="col-md-8">
-      <h2>Sign up</h2>
-      <p>Already have an account? <a ui-sref="authentication.signin" class="show-signup">Sign in</a></p>
-      <br/>
-      <form name="vm.userForm" ng-submit="vm.signup(vm.userForm.$valid)" class="signin" novalidate autocomplete="off">
-        <fieldset>
-          <div class="row">
-            <div class="form-group col-sm-8" show-errors>
-              <label for="firstName">First Name</label>
-              <input type="text" id="firstName" name="firstName" class="form-control" ng-model="vm.credentials.firstName"
-                placeholder="First Name" required>
-              <div ng-messages="vm.userForm.firstName.$error" role="alert">
-                <p class="help-block error-text" ng-message="required">First name is required.</p>
-              </div>
-            </div>
-          </div>
-          <div class="row">    
-            <div class="form-group col-sm-8" show-errors>
-              <label for="lastName">Last Name</label>
-              <input type="text" id="lastName" name="lastName" class="form-control" ng-model="vm.credentials.lastName"
-                placeholder="Last Name" required>
-              <div ng-messages="vm.userForm.lastName.$error" role="alert">
-                <p class="help-block error-text" ng-message="required">Last name is required.</p>
-              </div>
-            </div>
-          </div>
-          <div class="row">
-            <div class="form-group col-sm-8" show-errors>
-              <label for="email">Email</label>
-              <input type="email" id="email" name="email" class="form-control" ng-model="vm.credentials.email"
-              ng-pattern="/^\w+([.-]?\w+)@\w+([.-]?\w+)(.\w{2,3})+$/" placeholder="email@example.com" lowercase required>
-              <div ng-messages="vm.userForm.email.$error" role="alert">
-                <p class="help-block error-text" ng-message="required">Email address is required.</p>
-                <p class="help-block error-text" ng-message="email">Email address is invalid.</p>
-              </div>
-            </div>
-        </div>
+        <h2>Sign up</h2>
+        <p>Already have an account? <a ui-sref="authentication.signin" class="show-signup">Sign in</a></p>
+        <br/>
+        <form name="vm.userForm" ng-submit="vm.signup(vm.userForm.$valid)" class="signin" novalidate autocomplete="off">
+            <fieldset>
+                <!-- FIRST NAME -->
+                <!-- =============================================================================================== -->
+                <div class="row">
+                    <div class="form-group col-sm-8" show-errors>
+                        <label for="firstName">First Name</label>
+                        <input type="text" id="firstName" name="firstName" class="form-control" ng-model="vm.credentials.firstName"
+                        placeholder="First Name" required>
+                        <div ng-messages="vm.userForm.firstName.$error" role="alert">
+                            <p class="help-block error-text" ng-message="required">First name is required.</p>
+                        </div>
+                    </div>
+                </div>
 
-        <div class="row">
-          <div class="form-group col-sm-4" show-errors>
-            <label for="role" class="control-label required">Role</label>
-            <div class="radio">
-              <label>
-                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
-                Adult - Team Lead
-              </label>
-            </div>
-            <div class="radio">
-              <label>
-                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
-                Student - Team Member
-              </label>
-            </div>
+                <!-- LAST NAME -->
+                <!-- =============================================================================================== -->
+                <div class="row">
+                    <div class="form-group col-sm-8" show-errors>
+                        <label for="lastName">Last Name</label>
+                        <input type="text" id="lastName" name="lastName" class="form-control" ng-model="vm.credentials.lastName"
+                        placeholder="Last Name" required>
+                        <div ng-messages="vm.userForm.lastName.$error" role="alert">
+                            <p class="help-block error-text" ng-message="required">Last name is required.</p>
+                        </div>
+                    </div>
+                </div>
 
+                <!-- EMAIL -->
+                <!-- =============================================================================================== -->
+                <div class="row">
+                    <div class="form-group col-sm-8" show-errors>
+                        <label for="email">Email</label>
+                        <input type="email" id="email" name="email" class="form-control" ng-model="vm.credentials.email"
+                        ng-pattern="/^\w+([.-]?\w+)@\w+([.-]?\w+)(.\w{2,3})+$/" placeholder="email@example.com" lowercase required>
+                        <div ng-messages="vm.userForm.email.$error" role="alert">
+                            <p class="help-block error-text" ng-message="required">Email address is required.</p>
+                            <p class="help-block error-text" ng-message="email">Email address is invalid.</p>
+                        </div>
+                    </div>
+                </div>
 
-           <!--  <select name="role" class="form-group" ng-model="vm.credentials.userrole" required
-            ng-change="vm.roleFieldSelected(vm.credentials.userrole)">
-              <option value="team lead pending">Team Lead</option>
-              <option value="team member pending">Team Member</option>
-            </select> -->
-          </div>
+                <!-- ROLE -->
+                <!-- =============================================================================================== -->
+                <div class="row">
+                    <div class="form-group col-sm-4" show-errors>
+                        <label for="role" class="control-label required">Role</label>
+                        <div class="radio">
+                            <label>
+                                <input
+                                    type="radio"
+                                    ng-model="vm.credentials.userrole"
+                                    value="team lead pending"
+                                    required
+                                >
+                                Adult - Team Lead
+                            </label>
+                        </div>
+                        <div class="radio">
+                            <label>
+                                <input
+                                    type="radio"
+                                    ng-model="vm.credentials.userrole"
+                                    value="team member pending"
+                                    required
+                                >
+                                Student - Team Member
+                            </label>
+                        </div>
+                    </div>
+                    <div class="form-group col-sm-8">
+                        <span class="help-block">
+                            The platform has two roles- “team lead” for adults and “team member” for students.  Team leads assign activities (like data collection protocols) to team members.  Team leads are also responsible for reviewing any data or content submitted by team members.
+                        </span>
+                    </div>
+                </div>
 
-          <div class="form-group col-sm-8">
-             <span class="help-block">
-              The platform has two roles- “team lead” for adults and “team member” for students.  Team leads assign activities (like data collection protocols) to team members.  Team leads are also responsible for reviewing any data or content submitted by team members.
-            </span>
-          </div>
+                <!-- TEAM LEAD TYPE (if role == team-lead) -->
+                <!-- =============================================================================================== -->
+                <div class="row" ng-show="vm.credentials.userrole == 'team lead pending'">
+                    <div class="form-group col-sm-4" show-errors>
+                        <label for="role" class="control-label required">Team Lead Type</label>
 
-          <div class="row">
-          <div class="form-group col-sm-4" show-errors>
-            <label for="role" class="control-label required">Team Lead Type</label>
-            <div class="radio">
-              <label>
-                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
-                Teacher
-              </label>
-            </div>
-            <div class="radio">
-              <label>
-                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
-                Non-profit Partner/Informal Educator
-              </label>
-            </div>
-             <div class="radio">
-              <label>
-                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
-                Community Scientist
-              </label>
-            </div>
-             <div class="radio">
-              <label>
-                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
-                Professional Scientist
-              </label>
-            </div>
-             <div class="radio">
-              <label>
-                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
-                Other
-              </label>
-            </div>
-          </div>
-           <div class="form-group col-sm-8">
-             <span class="help-block">
-              Select the type that most closely describes what you do.  “Community scientist” is the term we use for a volunteer citizen scientist.
-             </span>
-            </div> 
-           <div class="row">
-          <div class="form-group col-sm-4" show-errors>
-            <label for="role" class="control-label required">School Type</label>
-            <div class="radio">
-              <label>
-                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
-                NYC Public
-              </label>
-            </div>
-            <div class="radio">
-              <label>
-                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
-                NYC Charter
-              </label>
-            </div>
-             <div class="radio">
-              <label>
-                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
-                Private
-              </label>
-            </div>
-             <div class="radio">
-              <label>
-                <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
-                Other public
-              </label>
-            </div>
-            <div class="form-group col-sm-8">
-             <span class="help-block">
-              
-             </span>
-            </div> 
-          </div>  
-          <div class="form-group" show-errors ng-show="vm.teamLeadSelected"
-          ng-class="{'col-sm-8': !vm.teamLeadSelected, 'col-sm-8': vm.teamLeadSelected}">
-            <label for="teamLeadType" class="control-label" ng-class="{required: vm.teamLeadSelected}">Team Lead Type</label>
-            <select class="form-control" name="teamLeadType" id="teamLeadType" ng-model="vm.credentials.teamLeadType"
-              ng-required="vm.teamLeadSelected">
-              <option ng-repeat="type in vm.teamLeadType" value="{{type.value}}">{{type.label}}</option>
-            </select>
-          </div>
+                        <div class="radio">
+                            <label>
+                                <input
+                                    type="radio"
+                                    name="teamLeadType"
+                                    ng-model="vm.credentials.teamLeadType"
+                                    value="teacher"
+                                    required
+                                >
+                                Teacher
+                            </label>
+                        </div>
+                        <div class="radio">
+                            <label>
+                                <input
+                                    type="radio"
+                                    name="teamLeadType"
+                                    ng-model="vm.credentials.teamLeadType"
+                                    value="partner"
+                                    required
+                                >
+                                Non-profit Partner / Informal Educator
+                            </label>
+                        </div>
+                        <div class="radio">
+                            <label>
+                                <input
+                                    type="radio"
+                                    name="teamLeadType"
+                                    ng-model="vm.credentials.teamLeadType"
+                                    value="citizen scientist"
+                                    required
+                                >
+                                Community Scientist
+                            </label>
+                        </div>
+                        <div class="radio">
+                            <label>
+                                <input
+                                    type="radio"
+                                    name="teamLeadType"
+                                    ng-model="vm.credentials.teamLeadType"
+                                    value="professional scientist"
+                                    required
+                                >
+                                Professional Scientist
+                            </label>
+                        </div>
+                        <div class="radio">
+                            <label>
+                                <input
+                                    type="radio"
+                                    name="teamLeadType"
+                                    ng-model="vm.credentials.teamLeadType"
+                                    value="other"
+                                    required
+                                >
+                                Other
+                            </label>
+                        </div>
+                    </div>
+                    <div class="form-group col-sm-8">
+                        <span class="help-block">
+                            Select the type that most closely describes what you do.  “Community scientist” is the term we use for a volunteer citizen scientist.
+                        </span>
+                    </div>
+                </div>
+
+                <!-- SCHOOL TYPE (if team lead type == teacher) -->
+                <!-- =============================================================================================== -->
+                <div class="row" ng-show="vm.credentials.teamLeadType == 'teacher'">
+                    <div class="form-group col-sm-4" show-errors>
+                        <label for="role" class="control-label required">School Type</label>
+                        <div class="radio">
+                            <label>
+                                <input
+                                    type="radio"
+                                    name="schoolType"
+                                    ng-model="vm.credentials.schoolOrgType"
+                                    value="nyc-public"
+                                    required
+                                >
+                                NYC Public
+                            </label>
+                        </div>
+                        <div class="radio">
+                            <label>
+                                <input
+                                    type="radio"
+                                    name="schoolType"
+                                    ng-model="vm.credentials.schoolOrgType"
+                                    value="nyc-charter"
+                                    required
+                                >
+                                NYC Charter
+                            </label>
+                        </div>
+                        <div class="radio">
+                            <label>
+                                <input
+                                    type="radio"
+                                    name="schoolType"
+                                    ng-model="vm.credentials.schoolOrgType"
+                                    value="private"
+                                    required
+                                >
+                                Private
+                            </label>
+                        </div>
+                        <div class="radio">
+                            <label>
+                                <input
+                                    type="radio"
+                                    name="schoolType"
+                                    ng-model="vm.credentials.schoolOrgType"
+                                    value="other-public"
+                                    required
+                                >
+                                Other public
+                            </label>
+                        </div>
+                        <div class="form-group col-sm-8">
+                            <span class="help-block">
+                            </span>
+                        </div>
+                    </div>
+                    <div class="form-group" show-errors ng-show="vm.teamLeadSelected"
+                        ng-class="{'col-sm-8': !vm.teamLeadSelected, 'col-sm-8': vm.teamLeadSelected}">
+                        <label for="teamLeadType" class="control-label" ng-class="{required: vm.teamLeadSelected}">Team Lead Type</label>
+                        <select class="form-control" name="teamLeadType" id="teamLeadType" ng-model="vm.credentials.teamLeadType"
+                            ng-required="vm.teamLeadSelected">
+                            <option ng-repeat="type in vm.teamLeadType" value="{{type.value}}">{{type.label}}</option>
+                        </select>
+                    </div>
+                </div>
+
+                <!-- ORGANIZATION (NYC Public Schools) -->
+                <!-- =============================================================================================== -->
+                <div class="row" ng-show="vm.credentials.schoolOrgType=='nyc-public'">
+                    <div class="form-group col-sm-12" show-errors>
+                        <label for="schoolOrg" class="control-label required">Organization
+                            <a href="#" ng-click="vm.openFormOrg()" ng-show="vm.credentials.userrole === 'team lead pending'">(not listed?)</a>
+                        </label>
+                        <select
+                            class="form-control"
+                            name="schoolOrg"
+                            id="schoolOrg"
+                            ng-model="vm.credentials.schoolOrg"
+                            ng-change="vm.schoolOrgFieldSelected(vm.credentials.schoolOrg)"
+                            ng-disabled="!vm.credentials.teamLeadType || (vm.credentials.teamLeadType == 'teacher' && !vm.credentials.schoolOrgType)"
+                            required
+                        >
+                            <option ng-repeat="schoolOrg in vm.schoolOrgs" value="{{schoolOrg._id}}">{{schoolOrg.name}}</option>
+                        </select>
+                    </div>
+                    <div class="form-group" show-errors ng-show="vm.schoolOrgSelected"
+                        ng-class="{'col-sm-6': !vm.schoolOrgSelected, 'col-sm-4': vm.schoolOrgSelected}">
+                        <label for="teamLead" class="control-label" ng-class="{required: vm.schoolOrgSelected}">Team Lead</label>
+                        <select class="form-control" name="teamLead" id="teamLead" ng-model="vm.credentials.teamLead"
+                            ng-options="teamLead._id as teamLead.displayName for teamLead in vm.teamLeads"
+                            ng-required="vm.schoolOrgSelected">
+                        </select>
+                    </div>
+                </div>
+
+                <!-- ORGANIZATION (all others) -->
+                <!-- =============================================================================================== -->
+                <div class="row" ng-hide="vm.credentials.schoolOrgType=='nyc-public'">
+                    <div class="form-group col-sm-12" show-errors>
+                        <label for="schoolOrg" class="control-label required">Organization
+                            <a href="#" ng-click="vm.openFormOrg()" ng-show="vm.credentials.userrole === 'team lead pending'">(not listed?)</a>
+                        </label>
+                        <select
+                            class="form-control"
+                            name="schoolOrg"
+                            id="schoolOrg"
+                            ng-model="vm.credentials.schoolOrg"
+                            ng-change="vm.schoolOrgFieldSelected(vm.credentials.schoolOrg)"
+                            ng-disabled="!vm.credentials.teamLeadType || (vm.credentials.teamLeadType == 'teacher' && !vm.credentials.schoolOrgType)"
+                            required>
+                            <option ng-repeat="schoolOrg in vm.schoolOrgs" value="{{schoolOrg._id}}">{{schoolOrg.name}}</option>
+                        </select>
+                    </div>
+                    <div class="form-group" show-errors ng-show="vm.schoolOrgSelected"
+                        ng-class="{'col-sm-6': !vm.schoolOrgSelected, 'col-sm-4': vm.schoolOrgSelected}">
+                        <label for="teamLead" class="control-label" ng-class="{required: vm.schoolOrgSelected}">Team Lead</label>
+                        <select class="form-control" name="teamLead" id="teamLead" ng-model="vm.credentials.teamLead"
+                            ng-options="teamLead._id as teamLead.displayName for teamLead in vm.teamLeads"
+                            ng-required="vm.schoolOrgSelected">
+                        </select>
+                    </div>
+                </div>
+
+                <!-- USERNAME -->
+                <!-- =============================================================================================== -->
+                <div class="row">
+                    <div class="form-group col-sm-12" show-errors>
+                        <label for="username">Username</label>
+                        <input type="text" id="username" name="username" class="form-control" ng-model="vm.credentials.username"
+                        placeholder="Username" lowercase required>
+                        <div ng-messages="vm.userForm.username.$error" role="alert">
+                            <p class="help-block error-text" ng-message="required">Username is required.</p>
+                        </div>
+                    </div>
+                    <div class="form-group col-sm-6" show-errors>
+                        <label for="password">Password</label>
+                        <input type="password" id="password" name="password" class="form-control" ng-model="vm.credentials.password"
+                        placeholder="Password" uib-popover="{{vm.popoverMsg}}" uib-popover-trigger="focus" password-validator required>
+                        <div ng-messages="vm.userForm.password.$error" role="alert">
+                            <p class="help-block error-text" ng-message="required">Password is required.</p>
+                            <div ng-repeat="passwordError in passwordErrors">
+                                <p class="help-block" ng-show="vm.userForm.password.$error.requirements">{{passwordError}}</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group col-sm-6" show-errors>
+                        <label for="retypePassword">Retype Password</label>
+                        <input type="password" id="retypePassword" name="retypePassword" class="form-control"
+                        ng-model="vm.credentials.retypePassword" placeholder="Password" uib-popover="{{vm.popoverMsg}}"
+                        uib-popover-trigger="focus" password-verify="vm.credentials.password" required>
+                        <div ng-messages="vm.userForm.retypePassword.$error" role="alert">
+                            <p class="help-block error-text" ng-message="required">Password verification is required.</p>
+                            <p class="help-block" ng-show="vm.userForm.retypePassword.$error.passwordVerify">Passwords do not match.</p>
+                            <div ng-repeat="passwordError in passwordErrors">
+                                <p class="help-block" ng-show="vm.userForm.password.$error.requirements">{{passwordError}}</p>
+                            </div>
+                        </div>
+                        <div class="form-group" ng-show="!vm.userForm.password.$error.required">
+                            <label>Password Requirements</label>
+                            <uib-progressbar value="requirementsProgress" type="{{requirementsColor}}">
+                            <span style="color:white; white-space:nowrap;">{{requirementsProgress}}%</span>
+                            </uib-progressbar>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ACCEPT T&C -->
+                <!-- =============================================================================================== -->
+                <div class="row">
+                    <div class="col-sm-12 text-right">
+                        <div class="checkbox">
+                            <label>
+                                <input type="checkbox" ng-model="vm.hasAcceptedTermsOfUse" required> I agree to the <a href="#" data-toggle="modal" data-target="#modal-termsofuse">Terms of Use</a>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- SUBMIT -->
+                <!-- =============================================================================================== -->
+                <div class="row">
+                    <div class="col-sm-12 text-right form-group">
+                        <button type="submit" class="btn btn-primary pull-right" ng-show="!vm.isSubmitting">Sign up</button>
+                        <p class="info" ng-show="vm.isSubmitting"><i class="fa fa-spin fa-circle-o-notch blue"></i> Creating your account</p>
+                    </div>
+                    <div class="col-sm-12">
+                        <div ng-show="vm.error" class="alert alert-danger">
+                            <strong ng-bind="vm.error"></strong>
+                        </div>
+                    </div>
+                </fieldset>
+            </form>
         </div>
-        <div class="row">
-          <div class="form-group col-sm-12" show-errors>
-            <label for="schoolOrg" class="control-label required">Organization
-              <a href="#" ng-click="vm.openFormOrg()" ng-show="vm.credentials.userrole === 'team lead pending'">(not listed?)</a>
-            </label>
-            <select class="form-control" name="schoolOrg" id="schoolOrg" ng-model="vm.credentials.schoolOrg"
-              ng-change="vm.schoolOrgFieldSelected(vm.credentials.schoolOrg)" required>
-              <option ng-repeat="schoolOrg in vm.schoolOrgs" value="{{schoolOrg._id}}">{{schoolOrg.name}}</option>
-            </select>
-          </div>
-          <div class="form-group" show-errors ng-show="vm.schoolOrgSelected"
-          ng-class="{'col-sm-6': !vm.schoolOrgSelected, 'col-sm-4': vm.schoolOrgSelected}">
-            <label for="teamLead" class="control-label" ng-class="{required: vm.schoolOrgSelected}">Team Lead</label>
-            <select class="form-control" name="teamLead" id="teamLead" ng-model="vm.credentials.teamLead"
-              ng-options="teamLead._id as teamLead.displayName for teamLead in vm.teamLeads"
-              ng-required="vm.schoolOrgSelected">
-            </select>
-          </div>
-        </div>
-        <div class="row">
-          <div class="form-group col-sm-12" show-errors>
-            <label for="username">Username</label>
-            <input type="text" id="username" name="username" class="form-control" ng-model="vm.credentials.username"
-            placeholder="Username" lowercase required>
-            <div ng-messages="vm.userForm.username.$error" role="alert">
-              <p class="help-block error-text" ng-message="required">Username is required.</p>
-            </div>
-          </div>
-          <div class="form-group col-sm-6" show-errors>
-            <label for="password">Password</label>
-              <input type="password" id="password" name="password" class="form-control" ng-model="vm.credentials.password"
-              placeholder="Password" uib-popover="{{vm.popoverMsg}}" uib-popover-trigger="focus" password-validator required>
-            <div ng-messages="vm.userForm.password.$error" role="alert">
-              <p class="help-block error-text" ng-message="required">Password is required.</p>
-              <div ng-repeat="passwordError in passwordErrors">
-                <p class="help-block" ng-show="vm.userForm.password.$error.requirements">{{passwordError}}</p>
-              </div>
-            </div>
-          </div>
-          <div class="form-group col-sm-6" show-errors>
-            <label for="retypePassword">Retype Password</label>
-              <input type="password" id="retypePassword" name="retypePassword" class="form-control"
-              ng-model="vm.credentials.retypePassword" placeholder="Password" uib-popover="{{vm.popoverMsg}}"
-              uib-popover-trigger="focus" password-verify="vm.credentials.password" required>
-            <div ng-messages="vm.userForm.retypePassword.$error" role="alert">
-              <p class="help-block error-text" ng-message="required">Password verification is required.</p>
-              <p class="help-block" ng-show="vm.userForm.retypePassword.$error.passwordVerify">Passwords do not match.</p>
-              <div ng-repeat="passwordError in passwordErrors">
-                <p class="help-block" ng-show="vm.userForm.password.$error.requirements">{{passwordError}}</p>
-              </div>
-            </div>
-            <div class="form-group" ng-show="!vm.userForm.password.$error.required">
-              <label>Password Requirements</label>
-              <uib-progressbar value="requirementsProgress" type="{{requirementsColor}}">
-                <span style="color:white; white-space:nowrap;">{{requirementsProgress}}%</span>
-              </uib-progressbar>
-            </div>
-          </div>
-        </div>
-        <!--TODO: Wire up Terms of Use checkbox- make this required for signing up -->
-        <div class="row">
-          <div class="col-sm-12 text-right">
-              <div class="checkbox">
-                <label>
-                  <input type="checkbox" ng-model="vm.hasAcceptedTermsOfUse" required> I agree to the <a href="#" data-toggle="modal" data-target="#modal-termsofuse">Terms of Use</a>
-                </label>
-              </div>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-sm-12 text-right form-group">
-              <button type="submit" class="btn btn-primary pull-right" ng-show="!vm.isSubmitting">Sign up</button>
-              <p class="info" ng-show="vm.isSubmitting"><i class="fa fa-spin fa-circle-o-notch blue"></i> Creating your account</p>
-          </div>
-          <div class="col-sm-12">
-              <div ng-show="vm.error" class="alert alert-danger">
-                  <strong ng-bind="vm.error"></strong>
-              </div>
-          </div>
-        </fieldset>
-      </form>
     </div>
-</div>
-
-
-
 
 <!-- MODALS -->
 <form-org-profile-modal organization="vm.newSchoolOrg" close-function="vm.closeFormOrg"></form-org-profile-modal>
 <!-- <form-school-org-modal school-org="vm.newSchoolOrg" save-school-org="false" save-function="vm.saveSchoolOrgForm"
 cancel-function="vm.cancelSchoolOrgForm"></form-school-org-modal> -->
-
 <div class="modal fade" id="modal-termsofuse" tabindex="-1" role="dialog" aria-labelledby="modal-termsofuse">
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content">
@@ -251,52 +366,35 @@ cancel-function="vm.cancelSchoolOrgForm"></form-school-org-modal> -->
             <div class="modal-body">
                 <h4><b>ACCEPTANCE OF TERMS</b></h4>
                 <p>This Agreement contains the complete terms and conditions that apply to your participation in the BOP Schools and Citizen Science Digital Platform, <a href="http://platform.bop.nyc/" target="_blank">http://platform.bop.nyc</a> (herein: "The Platform"). If you wish to use The Platform including its tools and services please read these terms of use carefully. By accessing the URL <a href="http://platform.bop.nyc/" target="_blank">http://platform.bop.nyc</a> or using any part of The Platform or any content or services hereof, you agree to become bound by these terms and conditions. If you do not agree to all the terms and conditions, then you may not access The Platform or use the content or any services in The Platform.</p>
-
                 <h4><b>MODIFICATIONS OF TERMS OF USE</b></h4>
                 <p>Amendments to this agreement can be made and effected by us from time to time without specific notice to your end. Agreement posted on The Platform reflects the latest agreement and you should carefully review the same before you use The Platform.</p>
-
                 <h4><b>USE OF THE PLATFORM</b></h4>
                 <p>The sole purpose of The Platform is to support teacher and student learning in the context of ecosystem restoration science and stewardship. The Platform allows users (students, teachers, and others) to upload, publish, and download data; upload, publish, and download curriculum; create and publish research; communicate within the network; register for events; and other forthcoming uses. Any use of The Platform that does not explicitly meet the sole purpose of The Platform (defined as supporting teachers and students learning in the context of ecosystem restoration science and stewardship) is prohibited. Furthermore, you are strictly prohibited from doing the following acts, to wit: (a) using The Platform, including its services, tools, and resources if you are not able to form legally binding contracts, are under the age of 12 and have not obtained parent/guardian consent, or are temporarily or indefinitely suspended from using The Platform, its services, or tools; (b) posting items defined as inappropriate; (c) collecting information about users' personal information; (d) manipulating the content of any item such that it interferes with other uses or other user experiences of The Platform; (f) posting false, inaccurate, misleading, defamatory, or libelous content; (g) broadcasting, publishing, or distributing any content you have accessed from The Platform outside of The Platform; (h) using any of the content you have accessed from The Platform in any setting or context that is not clearly educational-scientific in nature; (i) using or manipulating The Platform, including its services, tools, and resources, for any purpose that may be deemed revenue generating or commercial in nature.</p>
-
                 <h5><b>Registration Information</b></h5>
                 <p>For you to complete the sign-up process in The Platform, you must provide your full legal name, a valid email address, member name and any other information needed in order to complete the signup process. If you are signing up with the role of team lead you must qualify that you are 12 years or older and must be responsible for keeping your password secure and be responsible for all activities and contents that are uploaded under your account. You must not transmit any worms or viruses or any code of a destructive nature. Any information provided by you or gathered by The Platform or third parties during any visit to The Platform shall be subject to the terms of Billion Oyster Project's Privacy Policy.</p>
-
                 <h5><b>Term</b></h5>
                 <p>This Agreement will remain in full force and effect while you use The Platform. You may terminate your membership at any time for any reason by following the instructions on the "TERMINATION OF ACCOUNT" in the setting page. We may terminate your membership for any reason at any time. If you are using a paid version of the Service and we terminate your membership in the Service because you have breached this Agreement, you will not be entitled to any refund of unused subscription fees. Even after your membership is terminated, certain sections of this Agreement will remain in effect.</p>
-
                 <h4><b>NON-COMMERCIAL USE BY MEMBERS.</b></h4>
                 <p>Registered users of The Platform are prohibited from using the services of The Platform in connection with any commercial endeavors or ventures. This includes  (a) broadcasting, publishing, or distributing any content you have accessed from The Platform outside of The Platform; (b) using any of the content you have accessed from The Platform in any setting or context that is not clearly educational-scientific in nature;  or (c) using or manipulating The Platform, including its services, tools, and resources, for any purpose that may be deemed revenue generating or commercial in nature. Juridical persons or entities including but not limited to organizations, companies, and/or businesses may not register as users on The Platform and should not use The Platform for any purpose.</p>
-
                 <h4><b>LINKS & FRAMINGS</b></h4>
                 <p>Illegal and/or unauthorized uses of the Services, including unauthorized framing of or linking to The Platform will be investigated, and appropriate legal action may be taken. Some links, however, are welcome to The Platform and you are allowed to establish links to The Platform provided that you do so in a way that is fair and legal and does not damage the construct or reputation of The Platform.  You must not establish a link in such a way as to suggest any form of association, approval, or endorsement on behalf of The Platform where none exists.  You must not establish a link from any website or service that is not owned by you.  You may not establish a link to any part of The Platform other than the homepage or frame content from The Platform on any other website or service without express written permission from the New York Harbor Foundation.</p>
-
                 <h4><b>WARRANTY DISCLAIMER AND EXCLUSIONS / LIMITATIONS OF LIABILITY</b></h4>
                 <p>We make no express or implied warranties or representations with respect to the Platform or any resources available through the Platform. In addition, we make no representation that the operation of The Platform will be uninterrupted or error-free, and we will not be liable for the consequences of any interruptions or errors. We may change, restrict access to, suspend or discontinued The Platform or any part of it at anytime. The information, content and services on The Platform are provided on an "as is" basis. When you use The Platform and or participate therein, you understand and agree that you participate at your own risk.</p>
-
                 <h4><b>INTELLECTUAL PROPERTY RIGHTS</b></h4>
                 <p>The Platform, which includes, but is not limited to, text, content photographs, video, audio, graphics, and look and feel, is protected by copyrights, trademarks, service marks and other proprietary rights and laws of the U.S. and other countries (the "Intellectual Property Rights"). The Platform is protected as a collective work or compilation under U.S. copyright and other laws and treaties. </p>
-
                 <p>You hereby acknowledge that all rights, titles and interests, including but not limited to rights covered by the Intellectual Property Rights, in and to The Platform, and that You will not acquire any right, title, or interest in or to The Platform except as expressly set forth in this Agreement. You will not modify, adapt, translate, prepare derivative works from, decompile, reverse engineer, disassemble or otherwise attempt to derive source code from any of our services, software, or documentation, or create or attempt to create a substitute or similar service or product through use of or access to the Program or proprietary information related thereto.</p>
-
                 <p>You agree to only use The Platform for nonprofit educational purposes only. To the extent that you must reproduce copies of the materials made available to you for nonprofit educational purposes through The Platform, You agree to limit the number of reproductions to one copy per student. </p>
-
                 <p>The Intellectual Property Rights embodied in and by The Platform are  further governed by stipulations of the National Science Foundation found at <a href="https://www.nsf.gov/pubs/2002/nsf02151/gpm7.jsp#730" target="_blank">https://www.nsf.gov/pubs/2002/nsf02151/gpm7.jsp#730</a></p>
-
                 <h5><b>Confidentiality</b></h5>
                 <p>You agree not to disclose information you obtain from us and or from our clients, advertisers, suppliers and forum members. All information submitted to by an end-user customer pursuant to a Program is proprietary information of Billion Oyster Project. Such customer information is confidential and may not be disclosed. Publisher agrees not to reproduce, disseminate, sell, distribute or commercially exploit any such proprietary information in any manner.</p>
-
                 <h4><b>NON-ASSIGNMENT OF RIGHTS</b></h4>
                 <p>Your rights of whatever nature cannot be assigned nor transferred to anybody, and any such attempt may result in termination of this Agreement, without liability to us. However, we may assign this Agreement to any person at any time without notice.</p>
-
                 <h5><b>Waiver</b></h5>
                 <p>Failure of the Billion Oyster Project to insist upon strict performance of any of the terms, conditions and covenants hereof shall not be deemed a relinquishment or waiver of any rights or remedy that the we may have, nor shall it be construed as a waiver of any subsequent breach of the terms, conditions or covenants hereof, which terms, conditions and covenants shall continue to be in full force and effect.</p>
-
                 <h5><b>and Severability of Terms.</b></h5>
                 <p>In the event that any provision of these Terms and Conditions is found invalid or unenforceable pursuant to any judicial decree or decision, such provision shall be deemed to apply only to the maximum extent permitted by law, and the remainder of these Terms and Conditions shall remain valid and enforceable according to its terms.</p>
-
                 <h5><b>Entire Agreement</b></h5>
                 <p>This Agreement shall be governed by and construed in accordance with the substantive laws of New York, without any reference to conflict-of-laws principles. The Agreement describes and encompasses the entire agreement between us and you, and supersedes all prior or contemporaneous agreements, representations, warranties and understandings with respect to The Platform, the contents and materials provided by or through The Platform, and the subject matter of this Agreement.</p>
-
                 <h5><b>Choice of Law; Jurisdiction; Forum</b></h5>
                 <p>Any dispute, controversy or difference which may arise between the parties out of, in relation to or in connection with this Agreement is hereby irrevocably submitted to the exclusive jurisdiction of the courts of New York, to the exclusion of any other courts without giving effect to its conflict of laws provisions or your actual state or country of residence.</p>
             </div>
@@ -306,5 +404,4 @@ cancel-function="vm.cancelSchoolOrgForm"></form-school-org-modal> -->
         </div>
     </div>
 </div>
-
 <!--END MODALS-->

--- a/modules/users/client/views/authentication/signup.client.view.html
+++ b/modules/users/client/views/authentication/signup.client.view.html
@@ -1,9 +1,29 @@
 <div class="row">
     <div class="col-md-8">
-        <h2>Sign up</h2>
-        <p>Already have an account? <a ui-sref="authentication.signin" class="show-signup">Sign in</a></p>
+        <div style="margin: 19px"> 
+            <h2>Sign up</h2>
+            <p>Already have an account? <a ui-sref="authentication.signin" class="show-signup">Sign in</a></p>
+        </div>    
+        <div class="well">
+            <p>
+                At Billion Oyster Project, we believe that teamwork is fundamental to restoring New York Harbor!  That’s why we’ve designed the BOP Digital Platform to support <strong>teams</strong> managed by adult <strong>team leads</strong> and composed of student <strong>team members</strong>.  Each team belongs to an <strong>organization</strong> like a school, non-profit, or business.  
+            </p>
+            <p>
+                (If you’re a volunteer community scientist- our name for “citizen scientist”- who isn’t representing an organization, not to worry!  Just select “Unaffiliated/None” as your organization.)
+            </p>
+        </div>    
         <br/>
-        <form name="vm.userForm" ng-submit="vm.signup(vm.userForm.$valid)" class="signin" novalidate autocomplete="off">
+        <form
+            name="vm.userForm"
+            ng-submit="vm.signup(vm.userForm.$valid)"
+            class="signin"
+            novalidate
+            autocomplete="off"
+            style="
+                margin:     19px;
+                margin-top: -20px;
+            "
+        >
             <fieldset>
                 <!-- FIRST NAME -->
                 <!-- =============================================================================================== -->
@@ -75,10 +95,12 @@
                     </div>
                     <div class="form-group col-sm-8">
                         <span class="help-block">
-                            The platform has two roles- “team lead” for adults and “team member” for students.  Team leads assign activities (like data collection protocols) to team members.  Team leads are also responsible for reviewing any data or content submitted by team members.
+                            If you’re an adult, select “Team Lead.”  If you’re a student, select “Team Member.”
                         </span>
                     </div>
                 </div>
+
+                <!-- FOR TEAM LEADS: -->
 
                 <!-- TEAM LEAD TYPE (if role == team-lead) -->
                 <!-- =============================================================================================== -->
@@ -204,7 +226,7 @@
                                     value="other-public"
                                     required
                                 >
-                                Other public
+                                Other municipality public/charter
                             </label>
                         </div>
                         <div class="form-group col-sm-8">
@@ -212,23 +234,23 @@
                             </span>
                         </div>
                     </div>
-                    <div class="form-group" show-errors ng-show="vm.teamLeadSelected"
-                        ng-class="{'col-sm-8': !vm.teamLeadSelected, 'col-sm-8': vm.teamLeadSelected}">
-                        <label for="teamLeadType" class="control-label" ng-class="{required: vm.teamLeadSelected}">Team Lead Type</label>
-                        <select class="form-control" name="teamLeadType" id="teamLeadType" ng-model="vm.credentials.teamLeadType"
-                            ng-required="vm.teamLeadSelected">
-                            <option ng-repeat="type in vm.teamLeadType" value="{{type.value}}">{{type.label}}</option>
-                        </select>
+                    <div class="form-group col-sm-8">
+                        <span class="help-block">
+                            Select whether your school is a NYC public, NYC charter, private, or public/charter school from outside NYC.  (We use this field to automatically populate information about NYC public schools.)
+                        </span>
                     </div>
                 </div>
 
                 <!-- ORGANIZATION (NYC Public Schools) -->
                 <!-- =============================================================================================== -->
-                <div class="row" ng-show="vm.credentials.schoolOrgType=='nyc-public'">
+                <div class="row" ng-show="
+                    vm.credentials.schoolOrgType == 'teacher' && vm.credentials.schoolOrgType=='nyc-public'
+                ">
                     <div class="form-group col-sm-12" show-errors>
-                        <label for="schoolOrg" class="control-label required">Organization
-                            <a href="#" ng-click="vm.openFormOrg()" ng-show="vm.credentials.userrole === 'team lead pending'">(not listed?)</a>
-                        </label>
+                        <label for="schoolOrg" class="control-label required">Organization</label>
+                        <span class="help-block">
+                            Start typing your school’s name, number, or ATS code in the field below, then select your school from the dropdown list.
+                        </span>
                         <select
                             class="form-control"
                             name="schoolOrg"
@@ -238,26 +260,55 @@
                             ng-disabled="!vm.credentials.teamLeadType || (vm.credentials.teamLeadType == 'teacher' && !vm.credentials.schoolOrgType)"
                             required
                         >
-                            <option ng-repeat="schoolOrg in vm.schoolOrgs" value="{{schoolOrg._id}}">{{schoolOrg.name}}</option>
+                            <option ng-repeat="schoolOrg in vm.schoolOrgs" value="{{schoolOrg._id}}">
+                                {{schoolOrg.name}}
+                            </option>
                         </select>
-                    </div>
-                    <div class="form-group" show-errors ng-show="vm.schoolOrgSelected"
-                        ng-class="{'col-sm-6': !vm.schoolOrgSelected, 'col-sm-4': vm.schoolOrgSelected}">
-                        <label for="teamLead" class="control-label" ng-class="{required: vm.schoolOrgSelected}">Team Lead</label>
-                        <select class="form-control" name="teamLead" id="teamLead" ng-model="vm.credentials.teamLead"
-                            ng-options="teamLead._id as teamLead.displayName for teamLead in vm.teamLeads"
-                            ng-required="vm.schoolOrgSelected">
-                        </select>
+                        <span class="help-block">
+                            Note: If you work at a NYC public school, your school should already appear as an organization in this list.  If you don't see your NYC public school on the list, contact <a href="mailto:bop.digital.platform@nyharbor.org">bop.digital.platform@nyharbor.org</a>.
+                        </span>
                     </div>
                 </div>
 
-                <!-- ORGANIZATION (all others) -->
+                <!-- ORGANIZATION (all other team leads) -->
                 <!-- =============================================================================================== -->
                 <div class="row" ng-hide="vm.credentials.schoolOrgType=='nyc-public'">
                     <div class="form-group col-sm-12" show-errors>
+                        <label for="schoolOrg" class="control-label required">Organization</label>
+                        <span class="help-block">
+                            Start typing your organization's name in the field below, then select your organization from the dropdown list.  If you're a community scientist who isn't representing an organization, select "Unaffiliated/None."
+                        </span>
+                         <span class="help-block">
+                            If your organization is not listed above, you can <a href="#" ng-click="vm.openFormOrg()">add an organization</a>.
+                        </span>
+                        <select
+                            class="form-control"
+                            name="schoolOrg"
+                            id="schoolOrg"
+                            ng-model="vm.credentials.schoolOrg"
+                            ng-change="vm.schoolOrgFieldSelected(vm.credentials.schoolOrg)"
+                            ng-disabled="!vm.credentials.teamLeadType || (vm.credentials.teamLeadType == 'teacher' && !vm.credentials.schoolOrgType)"
+                            required>
+                            <option ng-repeat="schoolOrg in vm.schoolOrgs" value="{{schoolOrg._id}}">{{schoolOrg.name}}</option>
+                        </select>
+                         <span class="help-block">
+                            Note: only select "Billion Oyster Project" if you are a staff member at Billion Oyster Project.
+                        </span>
+                    </div>
+                </div>
+
+                <!-- FOR TEAM MEMBERS -->
+
+                <!--ORGANIZATION (team members).  Hides "Add an org" text.-->
+                <!-- =============================================================================================== -->
+                <div class="row" ng-show="vm.credentials.userrole === 'team member pending'">
+                    <div class="form-group col-sm-12" show-errors>
                         <label for="schoolOrg" class="control-label required">Organization
-                            <a href="#" ng-click="vm.openFormOrg()" ng-show="vm.credentials.userrole === 'team lead pending'">(not listed?)</a>
+                            <a href="#" ng-click="vm.openFormOrg()"></a>
                         </label>
+                        <span class="help-block">
+                            Start typing your organization's name in the field below, then select your organization from the dropdown list."
+                        </span>
                         <select
                             class="form-control"
                             name="schoolOrg"
@@ -269,15 +320,10 @@
                             <option ng-repeat="schoolOrg in vm.schoolOrgs" value="{{schoolOrg._id}}">{{schoolOrg.name}}</option>
                         </select>
                     </div>
-                    <div class="form-group" show-errors ng-show="vm.schoolOrgSelected"
-                        ng-class="{'col-sm-6': !vm.schoolOrgSelected, 'col-sm-4': vm.schoolOrgSelected}">
-                        <label for="teamLead" class="control-label" ng-class="{required: vm.schoolOrgSelected}">Team Lead</label>
-                        <select class="form-control" name="teamLead" id="teamLead" ng-model="vm.credentials.teamLead"
-                            ng-options="teamLead._id as teamLead.displayName for teamLead in vm.teamLeads"
-                            ng-required="vm.schoolOrgSelected">
-                        </select>
-                    </div>
                 </div>
+
+                <!-- SELECT YOUR TEAM LEAD (if role = team member). -->
+                <!-- =============================================================================================== -->
 
                 <!-- USERNAME -->
                 <!-- =============================================================================================== -->

--- a/modules/users/server/controllers/users/users.authentication.server.controller.js
+++ b/modules/users/server/controllers/users/users.authentication.server.controller.js
@@ -9,7 +9,7 @@ var path = require('path'),
   email = require(path.resolve('./modules/core/server/controllers/email.server.controller')),
   mongoose = require('mongoose'),
   passport = require('passport'),
-  pivot = require('./modules/core/server/helpers/pivot.server.helper'),
+  pivot = require(path.resolve('./modules/core/server/helpers/pivot.server.helper')),
   User = mongoose.model('User'),
   UserActivity = mongoose.model('UserActivity'),
   SchoolOrg = mongoose.model('SchoolOrg'),
@@ -215,8 +215,8 @@ exports.signup = function (req, res) {
   };
 
   if (
-      req.body.userrole      === 'team lead pending' &&
-      req.body.teamLeadType  === 'teacher'           &&
+      req.body.userrole === 'team lead pending' &&
+      req.body.teamLeadType === 'teacher' &&
       req.body.schoolOrgType === 'nyc-public'
   ) {
     var existingOrg = SchoolOrg.findById(req.body.schoolOrg);

--- a/modules/users/server/controllers/users/users.authentication.server.controller.js
+++ b/modules/users/server/controllers/users/users.authentication.server.controller.js
@@ -9,6 +9,7 @@ var path = require('path'),
   email = require(path.resolve('./modules/core/server/controllers/email.server.controller')),
   mongoose = require('mongoose'),
   passport = require('passport'),
+  pivot = require('./modules/core/server/helpers/pivot.server.helper'),
   User = mongoose.model('User'),
   UserActivity = mongoose.model('UserActivity'),
   SchoolOrg = mongoose.model('SchoolOrg'),
@@ -213,8 +214,39 @@ exports.signup = function (req, res) {
     });
   };
 
-  if (req.body.schoolOrg === 'new') {
+  if (
+      req.body.userrole      === 'team lead pending' &&
+      req.body.teamLeadType  === 'teacher'           &&
+      req.body.schoolOrgType === 'nyc-public'
+  ) {
+    var existingOrg = SchoolOrg.findById(req.body.schoolOrg);
+
+    if (existingOrg) {
+      // org exists, so lets use that
+      user.schoolOrg = existingOrg;
+      createUser();
+
+    } else {
+      // org does not exist, so check the prospective orgs table for the ID
+      var prospectiveOrg = pivot.collection('prospectiveorgs').get(req.body.schoolOrg, function(err, record){
+        if (err) {
+          res.status(400).send({
+            message: 'Given organization ID is not valid',
+          });
+        } else {
+          // TODO: take this prospective org and copy it into school orgs
+
+          // user.schoolOrg = SchoolOrg.findById(record.id);
+
+          createUser();
+        }
+      });
+    }
+
+
+  } else if (req.body.schoolOrg === 'new') {
     user.schoolOrg = null;
+
     createNewOrg(function() {
       createUser();
     });

--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -105,7 +105,7 @@ var UserSchema = new Schema({
   },
   teamLeadType: {
     type: String,
-    enum: ['teacher', 'citizen scientist', 'professional scientist', 'site coordinator', 'other']
+    enum: ['teacher', 'citizen scientist', 'professional scientist', 'site coordinator', 'partner', 'other']
   },
   updated: {
     type: Date

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "grunt-mocha-istanbul": "~2.4.0",
     "grunt-mocha-test": "~0.12.7",
     "grunt-ng-annotate": "~1.0.1",
-    "grunt-node-inspector": "~0.3.0",
     "grunt-nodemon": "~0.4.0",
     "grunt-protractor-coverage": "~0.2.15",
     "grunt-protractor-runner": "~2.1.0",


### PR DESCRIPTION
This pushes frontend changes to the sign up page that adds a typeahead field for organizations (in lieu of a dropdown), breaks out type of school, and adds a typeahead list of all NYC public schools for those teachers to select from (to prevent duplicates, keep naming conventions consistent with the DOE, and allow schools to be searchable by both name and ATS code).

Backend changes are still in progress.

UN: bop-admin